### PR TITLE
Adding OpenCode Compatibility + CC enhancements

### DIFF
--- a/.agents/skills/drawio/SKILL.md
+++ b/.agents/skills/drawio/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: drawio
+description: Always use when user asks to create, generate, draw, or design a diagram, flowchart, architecture diagram, ER diagram, sequence diagram, class diagram, network diagram, mockup, wireframe, or UI sketch, or mentions draw.io, drawio, drawoi, .drawio files, or diagram export to PNG/SVG/PDF.
+---
+
+# Draw.io Diagram Skill
+
+Generate draw.io diagrams as native `.drawio` files. Optionally export to PNG, SVG, or PDF with the diagram XML embedded (so the exported file remains editable in draw.io).
+
+## How to create a diagram
+
+1. **Generate draw.io XML** in mxGraphModel format for the requested diagram
+2. **Write the XML** to a `.drawio` file in the current working directory using the Write tool
+3. **If the user requested an export format** (png, svg, pdf), locate the draw.io CLI (see below), export with `--embed-diagram`, then delete the source `.drawio` file. If the CLI is not found, keep the `.drawio` file and tell the user they can install the draw.io desktop app to enable export, or open the `.drawio` file directly
+4. **Open the result** — the exported file if exported, or the `.drawio` file otherwise. If the open command fails, print the file path so the user can open it manually
+
+## Choosing the output format
+
+Check the user's request for a format preference. Examples:
+
+- `/drawio create a flowchart` → `flowchart.drawio`
+- `/drawio png flowchart for login` → `login-flow.drawio.png`
+- `/drawio svg: ER diagram` → `er-diagram.drawio.svg`
+- `/drawio pdf architecture overview` → `architecture-overview.drawio.pdf`
+
+If no format is mentioned, just write the `.drawio` file and open it in draw.io. The user can always ask to export later.
+
+### Supported export formats
+
+| Format | Embed XML  | Notes                                    |
+| ------ | ---------- | ---------------------------------------- |
+| `png`  | Yes (`-e`) | Viewable everywhere, editable in draw.io |
+| `svg`  | Yes (`-e`) | Scalable, editable in draw.io            |
+| `pdf`  | Yes (`-e`) | Printable, editable in draw.io           |
+| `jpg`  | No         | Lossy, no embedded XML support           |
+
+PNG, SVG, and PDF all support `--embed-diagram` — the exported file contains the full diagram XML, so opening it in draw.io recovers the editable diagram.
+
+## draw.io CLI
+
+The draw.io desktop app includes a command-line interface for exporting.
+
+### Locating the CLI
+
+First, detect the environment, then locate the CLI accordingly:
+
+#### WSL2 (Windows Subsystem for Linux)
+
+WSL2 is detected when `/proc/version` contains `microsoft` or `WSL`:
+
+```bash
+grep -qi microsoft /proc/version 2>/dev/null && echo "WSL2"
+```
+
+On WSL2, use the Windows draw.io Desktop executable via `/mnt/c/...`:
+
+```bash
+DRAWIO_CMD=`/mnt/c/Program Files/draw.io/draw.io.exe`
+```
+
+The backtick quoting is required to handle the space in `Program Files` in bash.
+
+If draw.io is installed in a non-default location, check common alternatives:
+
+```bash
+# Default install path
+`/mnt/c/Program Files/draw.io/draw.io.exe`
+
+# Per-user install (if the above does not exist)
+`/mnt/c/Users/$WIN_USER/AppData/Local/Programs/draw.io/draw.io.exe`
+```
+
+#### macOS
+
+```bash
+/Applications/draw.io.app/Contents/MacOS/draw.io
+```
+
+#### Linux (native)
+
+```bash
+drawio   # typically on PATH via snap/apt/flatpak
+```
+
+#### Windows (native, non-WSL2)
+
+```
+"C:\Program Files\draw.io\draw.io.exe"
+```
+
+Use `which drawio` (or `where drawio` on Windows) to check if it's on PATH before falling back to the platform-specific path.
+
+### Export command
+
+```bash
+drawio -x -f <format> -e -b 10 -o <output> <input.drawio>
+```
+
+**WSL2 example:**
+
+```bash
+`/mnt/c/Program Files/draw.io/draw.io.exe` -x -f png -e -b 10 -o diagram.drawio.png diagram.drawio
+```
+
+Key flags:
+
+- `-x` / `--export`: export mode
+- `-f` / `--format`: output format (png, svg, pdf, jpg)
+- `-e` / `--embed-diagram`: embed diagram XML in the output (PNG, SVG, PDF only)
+- `-o` / `--output`: output file path
+- `-b` / `--border`: border width around diagram (default: 0)
+- `-t` / `--transparent`: transparent background (PNG only)
+- `-s` / `--scale`: scale the diagram size
+- `--width` / `--height`: fit into specified dimensions (preserves aspect ratio)
+- `-a` / `--all-pages`: export all pages (PDF only)
+- `-p` / `--page-index`: select a specific page (1-based)
+
+### Opening the result
+
+| Environment    | Command                                      |
+| -------------- | -------------------------------------------- |
+| macOS          | `open <file>`                                |
+| Linux (native) | `xdg-open <file>`                            |
+| WSL2           | `cmd.exe /c start "" "$(wslpath -w <file>)"` |
+| Windows        | `start <file>`                               |
+
+**WSL2 notes:**
+
+- `wslpath -w <file>` converts a WSL2 path (e.g. `/home/user/diagram.drawio`) to a Windows path (e.g. `C:\Users\...`). This is required because `cmd.exe` cannot resolve `/mnt/c/...` style paths.
+- The empty string `""` after `start` is required to prevent `start` from interpreting the filename as a window title.
+
+**WSL2 example:**
+
+```bash
+cmd.exe /c start "" "$(wslpath -w diagram.drawio)"
+```
+
+## File naming
+
+- Use a descriptive filename based on the diagram content (e.g., `login-flow`, `database-schema`)
+- Use lowercase with hyphens for multi-word names
+- For export, use double extensions: `name.drawio.png`, `name.drawio.svg`, `name.drawio.pdf` — this signals the file contains embedded diagram XML
+- After a successful export, delete the intermediate `.drawio` file — the exported file contains the full diagram
+
+## XML format
+
+A `.drawio` file is native mxGraphModel XML. Always generate XML directly — Mermaid and CSV formats require server-side conversion and cannot be saved as native files.
+
+### Basic structure
+
+Every diagram must have this structure:
+
+```xml
+<mxGraphModel adaptiveColors="auto">
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+    <!-- Diagram cells go here with parent="1" -->
+  </root>
+</mxGraphModel>
+```
+
+- Cell `id="0"` is the root layer
+- Cell `id="1"` is the default parent layer
+- All diagram elements use `parent="1"` unless using multiple layers
+
+## XML reference
+
+### Common styles
+
+**Rounded rectangle:**
+
+```xml
+<mxCell id="2" value="Label" style="rounded=1;whiteSpace=wrap;" vertex="1" parent="1">
+  <mxGeometry x="100" y="100" width="120" height="60" as="geometry"/>
+</mxCell>
+```
+
+**Diamond (decision):**
+
+```xml
+<mxCell id="3" value="Condition?" style="rhombus;whiteSpace=wrap;" vertex="1" parent="1">
+  <mxGeometry x="100" y="200" width="120" height="80" as="geometry"/>
+</mxCell>
+```
+
+**Arrow (edge):**
+
+```xml
+<mxCell id="4" value="" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="2" target="3" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+```
+
+### Style properties
+
+| Property                        | Values        | Use for                   |
+| ------------------------------- | ------------- | ------------------------- |
+| `rounded=1`                     | 0 or 1        | Rounded corners           |
+| `whiteSpace=wrap`               | wrap          | Text wrapping             |
+| `fillColor=#dae8fc`             | Hex color     | Background color          |
+| `strokeColor=#6c8ebf`           | Hex color     | Border color              |
+| `fontColor=#333333`             | Hex color     | Text color                |
+| `shape=cylinder3`               | shape name    | Database cylinders        |
+| `ellipse`                       | style keyword | Circles/ovals             |
+| `rhombus`                       | style keyword | Diamonds                  |
+| `edgeStyle=orthogonalEdgeStyle` | style keyword | Right-angle connectors    |
+| `dashed=1`                      | 0 or 1        | Dashed lines              |
+| `swimlane`                      | style keyword | Swimlane containers       |
+| `group`                         | style keyword | Invisible container       |
+| `container=1`                   | 0 or 1        | Enable container behavior |
+
+### Edge routing
+
+**CRITICAL: Every edge mxCell must contain a `<mxGeometry relative="1" as="geometry" />` child element.** Self-closing edge cells are invalid.
+
+- Use `edgeStyle=orthogonalEdgeStyle` for right-angle connectors
+- Space nodes generously — 200px horizontal / 120px vertical gaps
+- Use `exitX`/`exitY` and `entryX`/`entryY` (0-1) to control connection points
+- Leave at least 20px for arrowheads
+- Add explicit waypoints for overlapping edges
+
+### Containers
+
+Set `parent="containerId"` on child cells. Children use relative coordinates.
+
+| Type              | Style                          | When to use             |
+| ----------------- | ------------------------------ | ----------------------- |
+| Group (invisible) | `group;`                       | No visual border needed |
+| Swimlane (titled) | `swimlane;startSize=30;`       | Needs visible title bar |
+| Custom container  | `container=1;pointerEvents=0;` | Any shape as container  |
+
+### Dark mode
+
+Use `adaptiveColors="auto"` on mxGraphModel. Explicit colors auto-invert. Use `light-dark(lightColor,darkColor)` for manual control.
+
+## CRITICAL: XML well-formedness
+
+- **NEVER include ANY XML comments (`<!-- -->`) in the output.** XML comments are strictly forbidden.
+- Escape special characters in attribute values: `&amp;`, `&lt;`, `&gt;`, `&quot;`
+- Always use unique `id` values for each `mxCell`

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -2,6 +2,14 @@ Implement the plan at: $ARGUMENTS
 
 Model tier: **sonnet** — Sonnet 4.6 (1M context) session. All subagents: `model: "sonnet"`.
 
+Routing mode: `standard`, with an optional `batch` branch when every
+remaining phase is marked `[batch-eligible]`.
+
+Choose `standard` when the path is already planned, the blast radius is
+bounded by the approved phase, and the work should proceed through the
+normal implement-review-verify gate. Upgrade to `batch` only when the
+plan explicitly says the remaining phases are independent.
+
 Process:
 1. Read the plan completely. Check for existing checkmarks.
 2. Spawn Explore agents (model: `"sonnet"`) to gather relevant context.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -12,12 +12,18 @@ Process:
 7. Propose phase structure, get feedback.
 8. Write detailed plan with separate phase files.
 9. Use pseudocode notation for changes.
-10. Separate automated vs. manual success criteria.
-11. Identify batch-eligible phases: phases that are independent (no file overlap, no
+10. Add a compact **Verifier** section to each phase file with:
+    - target behavior
+    - automated checks
+    - fixtures/data/setup
+    - failure cases or edge conditions
+    - allowed manual exceptions
+11. Separate automated vs. manual success criteria.
+12. Identify batch-eligible phases: phases that are independent (no file overlap, no
     dependency on another phase's output) get marked `[batch-eligible]` in the plan.
     This tells `/implement` that `/batch` can execute them in parallel.
-12. Maximum 3 [NEEDS CLARIFICATION] markers.
-13. Iterate with user until all questions resolved.
+13. Maximum 3 [NEEDS CLARIFICATION] markers.
+14. Iterate with user until all questions resolved.
 
 Save to docs/plans/YYYY-MM-DD-[description].md
 Phase files: docs/plans/YYYY-MM-DD-[description]-phases/phase-N.md

--- a/.claude/commands/pre-launch.md
+++ b/.claude/commands/pre-launch.md
@@ -6,6 +6,12 @@ handoff.
 
 Model tier: **opus** — Claude Opus 4.6. All specialists: `model: "opus"`.
 
+Routing mode: `deep`
+
+Use this mode when the task demands a harsh, system-wide investigation
+with high blast radius and difficult verification, rather than a normal
+delivery pass.
+
 ## Mindset
 
 > Assume this product will be publicly launched soon and judged by users

--- a/.claude/commands/research.md
+++ b/.claude/commands/research.md
@@ -2,6 +2,12 @@ Research the codebase to answer: $ARGUMENTS
 
 Model tier: **opus** — Opus session. All subagents: `model: "opus"`.
 
+Routing mode: `deep`
+
+Choose this mode when ambiguity is high, the blast radius is unclear,
+the work is not yet reversible because you do not understand the system,
+or verification will depend on an accurate model of the current code.
+
 Process:
 1. Read any directly mentioned files FULLY before doing anything else.
 2. Break down the question into research areas.

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,5 +1,11 @@
 Quick project status check. Output a concise orientation and stop.
 
+Routing mode: `quick`
+
+Use this mode when the task is low-ambiguity, low-blast-radius, easily
+reversible, and you only need orientation before deciding whether to
+stop or move into the standard RPI flow.
+
 Run these commands and present the results in a compact summary:
 
 1. `git branch --show-current` — current branch

--- a/.claude/commands/triage.md
+++ b/.claude/commands/triage.md
@@ -92,6 +92,9 @@ Read-only. Do not modify any files.
    - Cross-reference findings (e.g., coverage report flags X needs tests, code quality report flags X has lint issues -- group them).
    - Identify patterns (multiple agents flagging the same area).
    - Check shared-context.md recommendations against report findings.
+   - If a carried item or repeated finding appears 3+ times, recommend a
+     promotion destination: rule, hook, scripted verifier, or
+     golden-case fixture.
 
 5. **Draft the action plan:**
 
@@ -148,6 +151,7 @@ Reports are NEVER committed (Rule #70). Only code fixes enter version control.
    - **Reports processed**: N
    - **Action items resolved**: M
    - **Summary**: [1-line summary of what was fixed]
+   - **Promotions proposed**: [rule / hook / scripted verifier / golden-case fixture, or "none"]
    **Cross-agent recommendations:**
    - [Agent]: recommendation based on triage findings
    <!-- ENTRY:END -->
@@ -209,6 +213,10 @@ Generate a triage report at `docs/agents/triage-report.md`:
 
 ## Carried Items (if any)
 [Items that persist across multiple triage cycles -- track for escalation]
+
+## Promotion Recommendations (if any)
+| Pattern | Evidence | Destination | Next step |
+|---------|----------|-------------|-----------|
 ```
 
 Present the report summary to the user.
@@ -222,6 +230,9 @@ Present the report summary to the user.
 - **Fix everything (Rule #58).** Categorize findings by severity, but implement 100% of action items. No deferring. No "nothing urgent."
 - **Read every report completely.** No skimming, no summaries-of-summaries. Extract ALL action items from every report.
 - **shared-context.md integration.** Read before analysis, append triage entry after completion.
+- **Promote repeated patterns.** If the same issue keeps returning,
+  recommend the smallest durable promotion: rule, hook, scripted
+  verifier, or golden-case fixture.
 - **CI accountability.** Push is not done until CI is green. Max 3 fix iterations.
 - **Branch verification before every commit.** Run `git branch --show-current` first (Error #33).
 - Run verification commands sequentially, never as parallel Bash calls.

--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -4,13 +4,18 @@ Model tier: **sonnet** — Sonnet 4.6 (1M context) session.
 
 Process:
 1. Locate the plan (provided path or search recent git history).
-2. Gather evidence: git log, git diff, run test suites.
+2. Read the plan's phase files and extract each phase's **Verifier** section.
+3. Gather evidence: git log, git diff, run test suites, inspect artifacts named in the verifier.
 3. For each phase:
    - Verify marked-complete items are actually done.
-   - Run every automated verification command.
-   - Think about edge cases.
+   - Check the phase against the verifier's target behavior.
+   - Run every automated verification command listed in the verifier.
+   - Confirm fixtures/data/setup assumptions match reality.
+   - Assess listed failure cases or edge conditions.
+   - Confirm any manual exceptions are justified.
 4. Generate a validation report with:
    - Implementation status per phase
+   - Verifier results per phase
    - Automated verification results
    - Code review findings (matches, deviations, issues)
    - Manual testing required (only if automation impossible — explain WHY)

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,5 @@
+[shell_environment_policy]
+inherit = "core"
+
+[shell_environment_policy.set]
+CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1"

--- a/.opencode/commands/adopt.md
+++ b/.opencode/commands/adopt.md
@@ -1,0 +1,9 @@
+---
+description: Adopt cc-rpi into an existing project using the canonical workflow
+---
+
+Follow the workflow in @templates/commands/adopt.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/.opencode/commands/bootstrap.md
+++ b/.opencode/commands/bootstrap.md
@@ -1,0 +1,9 @@
+---
+description: Bootstrap a project from cc-rpi using the canonical workflow
+---
+
+Follow the workflow in @templates/commands/bootstrap.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/.opencode/commands/describe-pr.md
+++ b/.opencode/commands/describe-pr.md
@@ -1,0 +1,9 @@
+---
+description: Generate a PR description using the canonical cc-rpi workflow
+---
+
+Follow the workflow in @.claude/commands/describe-pr.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/.opencode/commands/detach.md
+++ b/.opencode/commands/detach.md
@@ -1,0 +1,9 @@
+---
+description: Detach a project from cc-rpi using the canonical workflow
+---
+
+Follow the workflow in @templates/commands/detach.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/.opencode/commands/fix-ci.md
+++ b/.opencode/commands/fix-ci.md
@@ -1,0 +1,9 @@
+---
+description: Diagnose and fix CI using the canonical cc-rpi workflow
+---
+
+Follow the workflow in @.claude/commands/fix-ci.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/.opencode/commands/implement.md
+++ b/.opencode/commands/implement.md
@@ -1,0 +1,9 @@
+---
+description: Execute an implementation phase using the canonical cc-rpi workflow
+---
+
+Follow the workflow in @.claude/commands/implement.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/.opencode/commands/plan.md
+++ b/.opencode/commands/plan.md
@@ -1,0 +1,9 @@
+---
+description: Create an implementation plan using the canonical cc-rpi workflow
+---
+
+Follow the workflow in @.claude/commands/plan.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/.opencode/commands/pre-launch.md
+++ b/.opencode/commands/pre-launch.md
@@ -1,0 +1,9 @@
+---
+description: Run the pre-launch audit using the canonical cc-rpi workflow
+---
+
+Follow the workflow in @.claude/commands/pre-launch.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/.opencode/commands/release.md
+++ b/.opencode/commands/release.md
@@ -1,0 +1,9 @@
+---
+description: Prepare a release using the canonical cc-rpi workflow
+---
+
+Follow the workflow in @.claude/commands/release.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/.opencode/commands/remediate.md
+++ b/.opencode/commands/remediate.md
@@ -1,0 +1,9 @@
+---
+description: Remediate findings using the canonical cc-rpi workflow
+---
+
+Follow the workflow in @.claude/commands/remediate.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/.opencode/commands/research.md
+++ b/.opencode/commands/research.md
@@ -1,0 +1,9 @@
+---
+description: Research the codebase using the canonical cc-rpi workflow
+---
+
+Follow the workflow in @.claude/commands/research.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/.opencode/commands/status.md
+++ b/.opencode/commands/status.md
@@ -1,0 +1,9 @@
+---
+description: Show project status using the canonical cc-rpi workflow
+---
+
+Follow the workflow in @.claude/commands/status.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/.opencode/commands/triage.md
+++ b/.opencode/commands/triage.md
@@ -1,0 +1,9 @@
+---
+description: Process agent reports using the canonical cc-rpi workflow
+---
+
+Follow the workflow in @.claude/commands/triage.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/.opencode/commands/update-docs.md
+++ b/.opencode/commands/update-docs.md
@@ -1,0 +1,9 @@
+---
+description: Update documentation using the canonical cc-rpi workflow
+---
+
+Follow the workflow in @.claude/commands/update-docs.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/.opencode/commands/update.md
+++ b/.opencode/commands/update.md
@@ -1,0 +1,9 @@
+---
+description: Sync a project with cc-rpi using the canonical workflow
+---
+
+Follow the workflow in @templates/commands/update.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/.opencode/commands/validate.md
+++ b/.opencode/commands/validate.md
@@ -1,0 +1,9 @@
+---
+description: Validate implementation using the canonical cc-rpi workflow
+---
+
+Follow the workflow in @.claude/commands/validate.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,27 @@
 # Project: cc-rpi
 
-## Codex Compatibility
+## Codex and OpenCode Compatibility
 
 This repository is the cc-rpi blueprint. It is authored for Claude Code,
-but this `AGENTS.md` file makes the same methodology operable in Codex.
+but this `AGENTS.md` file makes the same methodology operable in Codex
+and OpenCode.
 
 Source of truth for this repo:
 
 - `CLAUDE.md` -- repo overview, workflow, commands, git conventions
 - `.claude/commands/*.md` -- active project-level workflow commands
 - `templates/commands/*.md` -- canonical exported command templates
+- `.opencode/commands/*.md` -- OpenCode command shims that dispatch to
+  the canonical `.claude/commands/*.md` workflow files
+- `templates/opencode/commands/*.md` -- exported OpenCode command shims
 - `.claude/rules/*.md` -- repo-local rules
 - `templates/rules/*.md` -- canonical exported rule templates
 - `.claude/skills/*/SKILL.md` and `templates/skills/*/SKILL.md` --
   skill content
 - `.codex/skills/*/SKILL.md` -- Codex-only skills that intentionally
   stay outside `.claude/skills/`
+- `opencode.json` and `templates/opencode.json.template` -- OpenCode
+  instruction loading for `CLAUDE.md` and `.claude/rules/*.md`
 
 ## Command Dispatch
 
@@ -29,7 +35,7 @@ When the user invokes a slash-style command:
 - Follow it as the workflow spec, translating Claude-specific mechanics
   to Codex equivalents when needed
 
-## Claude-to-Codex Translation
+## Claude-to-Codex/OpenCode Translation
 
 - `/simplify` -- prefer `codex-simplify` when available; otherwise run a
   dedicated post-implementation quality pass for reuse, cleanliness, and
@@ -42,6 +48,18 @@ When the user invokes a slash-style command:
 - `AskUserQuestion` -- ask the user directly only when the repo cannot
   answer safely
 - `/clear` and `/compact` -- treat as context-management guidance
+
+## OpenCode Command Dispatch
+
+When the user invokes a slash-style command in OpenCode:
+
+- Use the matching file in `.opencode/commands/` when it exists
+- Treat that file as a thin wrapper around the canonical
+  `.claude/commands/<name>.md` workflow, or the matching
+  `templates/commands/<name>.md` file for blueprint lifecycle commands
+- Preserve the existing slash command names; do not fork the workflow
+  into OpenCode-specific copies unless the command surface itself must
+  change
 
 ## Rules and Skills
 
@@ -62,6 +80,8 @@ When the user invokes a slash-style command:
   blueprint
 - `.codex/skills/` holds blueprint-shipped Codex-only skills; sync them
   into `~/.codex/skills/` for local Codex discovery
+- `.opencode/commands/` contains OpenCode wrappers only; the workflow
+  source of truth remains `.claude/commands/`
 - Research and plan docs in `docs/research/` and `docs/plans/` are
   committed history; `docs/agents/` is operational output and remains
   local-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- explicit routing modes (`quick`, `standard`, `deep`, `batch`) across
+  methodology docs, command specs, templates, and OpenCode wrappers so
+  users can choose workflow depth before choosing a command
+- log-promotion guidance that extends repeated patterns beyond prose-only
+  rules into hooks, scripted verifiers, and golden-case fixtures, with
+  matching triage and example updates
+- thin `INSTALL.md` / `VERIFY.md` manifests for the command bundle and
+  scheduled-agent bundle, with setup docs pointing to those local
+  references
+
+### Changed
+
+- **Branch-strategy guidance alignment** -- repo-local docs now state
+  explicitly that `cc-rpi` itself is maintained on `main`, while
+  exported template and methodology docs describe reusable branch
+  strategies more generically. Push-accountability, deployment-safety,
+  setup-checklist, and deployment-safety skill examples now refer to an
+  active development or integration branch where appropriate instead of
+  assuming every project uses `develop`.
+- **Plan/validate verification contract** -- planning docs, validation
+  docs, rules, guide text, and implementation-plan examples now define
+  a compact per-phase **Verifier** section with target behavior,
+  automated checks, fixtures/setup, edge cases, and allowed manual
+  exceptions, and `/validate` now reads against that contract.
+
 ## [1.17.0] - 2026-04-17
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,10 @@ Run verification sequentially with `&&` or `;`, NEVER as parallel Bash calls.
 
 ## Git Workflow
 
-**`main` is the only branch. Documentation project -- no develop/main split.**
+**Repo-local policy for this repository:** `main` is the only branch.
+This is how `cc-rpi` itself is maintained as a documentation-first
+blueprint. It is not the exported default for every project that adopts
+the blueprint.
 
 1. All work happens directly on `main`
 2. Always run markdownlint before committing

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -107,9 +107,24 @@ The agent reads the blueprint, then audits your project with three parallel agen
 
 The key difference: `/bootstrap` creates from templates. `/adopt` respects what exists and merges in what's missing.
 
+For reusable bundles that carry their own moving parts, the blueprint
+now colocates thin local manifests next to the bundle itself:
+
+- `templates/commands/INSTALL.md` and `templates/commands/VERIFY.md`
+- `templates/scripts/agents/INSTALL.md` and
+  `templates/scripts/agents/VERIFY.md`
+
+The setup checklist still acts as the top-level walkthrough; the bundle
+manifests hold local prerequisites and verification steps.
+
 Both commands now install `AGENTS.md` by default, so after setup the
 same `/research`, `/plan`, `/implement`, `/pre-launch`, `/update-docs`,
 and `/release` workflows can be driven from Codex too.
+
+During setup, adapt the branch model to the project instead of copying a
+single default blindly. Some projects use an integration-branch ->
+production flow such as `develop` -> `main`; others release directly
+from `main`.
 
 ### Step 3: Start Working
 
@@ -123,6 +138,16 @@ Once your project is set up (by either command), your daily workflow uses four s
 ```
 
 That's it. Those four commands are 90% of your interaction with the methodology.
+
+Before choosing among them, route the task:
+
+- `quick` — small, low-risk orientation work; usually `/status`
+- `standard` — normal delivery through RPI; usually `/plan`,
+  `/implement`, `/validate`
+- `deep` — research-heavy or audit-heavy work with unclear blast radius;
+  usually `/research` or `/pre-launch`
+- `batch` — only when planning already proved the remaining phases are
+  independent; triggered from `/implement` via `/batch`
 
 If you switch to Codex, the workflow names stay the same. `AGENTS.md`
 teaches Codex to interpret `.claude/commands/`, `.claude/rules/`, and
@@ -152,6 +177,19 @@ install when you want the same cleanup pass in Codex.
 | `/plan [feature]` | Creates a phased implementation plan with pseudocode, success criteria, and test requirements. Saves to `docs/plans/`. | After research is reviewed and approved. |
 | `/implement [plan path]` | Executes the plan one phase at a time. Reviewer checks plan compliance, then `/simplify` handles code quality. Stops after each phase. | After the plan is reviewed and approved. |
 | `/validate [plan path]` | Runs every automated check from the plan, verifies all phases are complete, produces a validation report. Recommends `/simplify` for quality findings. | After implementation is done. |
+
+### Routing Modes
+
+| Mode | Pick it when | Command mapping |
+|------|--------------|-----------------|
+| `quick` | Ambiguity is low, blast radius is small, and the next step is easy to reverse. | `/status` |
+| `standard` | The task already fits normal RPI execution with review gates. | `/plan`, `/implement`, `/validate` |
+| `deep` | Ambiguity is high, blast radius is unclear, or verification is hard without more investigation. | `/research`, `/pre-launch` |
+| `batch` | Planning has already marked the remaining phases `[batch-eligible]`. | `/batch` from `/implement` |
+
+The intake rule is simple: if ambiguity, blast radius, irreversibility,
+or verification difficulty increases, route deeper before you write
+code.
 
 ### Supporting Commands
 
@@ -216,10 +254,10 @@ You type `/plan add rate limiting to the login endpoint` and the agent:
 2. Explores the codebase for additional context.
 3. Asks you focused questions (only things the code can't answer).
 4. Proposes design options with trade-offs.
-5. Writes a phased implementation plan with pseudocode, file-by-file changes, and success criteria.
+5. Writes a phased implementation plan with pseudocode, file-by-file changes, a compact verifier section for each phase, and success criteria.
 6. Saves it to `docs/plans/` with separate files for each phase.
 
-Plans use a compact pseudocode notation so you can see exactly what changes in each file without reading full code blocks. Each phase has automated success criteria — tests that prove the phase works.
+Plans use a compact pseudocode notation so you can see exactly what changes in each file without reading full code blocks. Each phase also carries a verifier section that states target behavior, checks, setup assumptions, edge cases, and any allowed manual exceptions. The success criteria then turn that contract into concrete commands and review gates.
 
 **Your job:** Read the plan carefully. This is where your time has the highest leverage. A bad plan leads to hundreds of bad lines of code. Push back, ask questions, iterate until the plan is right.
 
@@ -246,8 +284,9 @@ You type `/validate docs/plans/2026-02-21-rate-limiting.md` and the agent:
 
 1. Re-reads the plan.
 2. Runs every automated verification command.
-3. Checks that all marked-complete items are actually done.
-4. Thinks about edge cases.
+3. Checks each phase against its verifier section.
+4. Checks that all marked-complete items are actually done.
+5. Thinks about edge cases.
 5. Produces a validation report.
 
 **Your job:** Review the report. If there are manual testing items (there should be very few), do them. Then you're done.
@@ -371,7 +410,11 @@ your-project/
 
 **Invest in your CLAUDE.md.** This file is the highest-leverage configuration point in the entire system. Every session reads it. Craft every line manually. If removing a line wouldn't cause mistakes, remove it.
 
-**Log your errors and successes.** When something goes wrong, write it down. When something goes perfectly, write it down. After 3 instances of the same pattern, promote it to a rule. This is how the blueprint itself was built.
+**Log your errors and successes.** When something goes wrong, write it
+down. When something goes perfectly, write it down. After 3 instances of
+the same pattern, promote it into the smallest durable asset that fits:
+rule, hook, scripted verifier, or golden-case fixture. This is how the
+blueprint itself was built.
 
 ## Advanced Setup
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Copy it into `~/.codex/skills/codex-simplify/` if you want a reusable
 equivalent of Claude Code's native `/simplify` without creating a
 project skill named `simplify`.
 
+The workflow now exposes a simple routing model before command choice:
+`quick` for orientation, `standard` for normal RPI delivery, `deep` for
+high-ambiguity investigation or audits, and `batch` for explicitly
+independent planned work.
+
 ## Guide
 
 New here? Read **[GUIDE.md](GUIDE.md)** — a human-readable walkthrough of the philosophy, the workflow, and every command. It covers everything you need to know without diving into every file. Also works great as source material for NotebookLM podcasts or articles.
@@ -84,6 +89,9 @@ Ready-to-use starting points for new projects:
 - **Rule templates** — `.claude/rules/` files with conditional loading (deployment, Supabase, testing) and universal rules (RPI details, push accountability)
 - **settings.json template** — `.claude/settings.json` with Agent Teams, hooks, and permissions
 - **Setup checklist** — Step-by-step guide including rules, skills, hooks, CI, and scheduled agents
+- **Bundle manifests** — thin `INSTALL.md` / `VERIFY.md` files for
+  representative reusable bundles such as `templates/commands/` and
+  `templates/scripts/agents/`
 - **Slash commands** — `/bootstrap`, `/adopt`, `/update`, `/research`, `/plan`, `/implement`, `/validate`, `/describe-pr`, `/pre-launch`, `/remediate`, `/triage`, `/status`, `/fix-ci` — plus Anthropic-native `/simplify` and `/batch`
 - **Scheduled agent scripts** — Nightly blueprint sync and multi-project morning triage with launchd/cron templates
 

--- a/examples/error-log.md
+++ b/examples/error-log.md
@@ -38,6 +38,14 @@ Asked Claude to "add validation to the API" without specifying which endpoints o
 3. Explicitly exclude areas that should not be touched
 4. Define "done" with concrete criteria, not adjectives like "properly"
 
+## Promotion Outcome
+
+- **Immediate:** add a rule to `patterns/quick-reference.md` about
+  scoping API changes to explicit endpoint paths
+- **If repeated 3+ times:** add a scripted verifier that checks only the
+  allowed endpoint files changed for the task, or otherwise flags the
+  over-broad edit set during validation or triage
+
 ## One-Line Lesson
 
 Scope API changes to specific endpoint paths and exclude what shouldn't be touched.

--- a/examples/implementation-plan-phases/phase-1.md
+++ b/examples/implementation-plan-phases/phase-1.md
@@ -44,6 +44,14 @@ Implementation notes:
 - Extract Redis key generation if shared with session storage
 - Ensure consistent error handling with existing patterns in `src/auth/tokens.ts:40-42`
 
+## Verifier
+
+- **Target behavior:** The rate limiter enforces the planned behavior and fails open when Redis is unavailable.
+- **Automated checks:** `pnpm test tests/auth/rate-limiter.test.ts`, `pnpm run typecheck`, `pnpm run lint`
+- **Fixtures / data / setup:** Real Redis test instance and isolated test keys
+- **Failure cases / edge conditions:** limit boundary, reset after expiry, retry-after value, concurrent increments, Redis outage
+- **Allowed manual exceptions:** None
+
 ## Verification
 
 ```bash

--- a/examples/implementation-plan.md
+++ b/examples/implementation-plan.md
@@ -39,6 +39,13 @@ fail: Redis down -> allow request (fail-open)
 risk: clock skew across replicas
 ```
 
+**Verifier:**
+- **Target behavior:** The rate limiter returns allow/limit decisions with retry metadata and fails open when Redis is unavailable.
+- **Automated checks:** `pnpm test tests/auth/rate-limiter.test.ts`, `pnpm run typecheck`, `pnpm run lint`
+- **Fixtures / data / setup:** Real Redis test instance with deterministic test keys
+- **Failure cases / edge conditions:** limit boundary, window reset, concurrent increments, Redis outage
+- **Allowed manual exceptions:** None
+
 **Success criteria:**
 - Automated:
   - [ ] Unit tests pass: `pnpm test tests/auth/rate-limiter.test.ts`
@@ -65,6 +72,13 @@ fx: HTTP 429 response; Retry-After header
 fail: malformed body -> skip email limit (IP-only)
 ```
 
+**Verifier:**
+- **Target behavior:** Middleware blocks limited login attempts and preserves normal auth flow for allowed requests.
+- **Automated checks:** `pnpm test tests/integration/rate-limit.test.ts`, `pnpm test tests/auth/`, `pnpm run typecheck`
+- **Fixtures / data / setup:** Request fixtures covering IP-only and email-aware checks
+- **Failure cases / edge conditions:** malformed body, IP-limited requests, email-limited requests
+- **Allowed manual exceptions:** None
+
 **Success criteria:**
 - Automated:
   - [ ] Integration tests pass: `pnpm test tests/integration/rate-limit.test.ts`
@@ -87,6 +101,13 @@ do:
 fx: route now has rate limiting; config externalizes limits
 risk: middleware ordering (rate limit must run before body parsing if body-dependent)
 ```
+
+**Verifier:**
+- **Target behavior:** The login route is wired to rate limiting with configuration exposed through project settings.
+- **Automated checks:** `pnpm test`, `pnpm run build`, `pnpm run typecheck`, `pnpm run lint`
+- **Fixtures / data / setup:** Environment defaults present for the rate-limit config
+- **Failure cases / edge conditions:** middleware ordering, missing env overrides, auth regressions
+- **Allowed manual exceptions:** None
 
 **Success criteria:**
 - Automated:

--- a/examples/success-log.md
+++ b/examples/success-log.md
@@ -33,3 +33,11 @@ This pattern works well for any "add a new feature that mirrors an existing one.
 2. Reference that pattern explicitly in the plan
 3. Constrain the first phase to the core functionality only
 4. Defer cross-cutting concerns (auth, error handling, edge cases) to later phases
+
+## Promotion Outcome
+
+- Promote the lesson to a reusable planning rule: explicitly reference
+  an existing code pattern when the feature should mirror it
+- If the same mirrored feature shape succeeds repeatedly, preserve one
+  representative implementation and its test inputs as a golden-case
+  fixture for future planning and validation

--- a/examples/workflows/refactor-existing-code.md
+++ b/examples/workflows/refactor-existing-code.md
@@ -207,6 +207,7 @@ Claude: Starting Phase 3: Fix refresh token bug + cleanup
 [deletes src/utils/token.ts — all logic now in AuthService]
 [removes dead imports from auth.ts and auth routes]
 [adds regression test for the refresh token expiry bug]
+[preserves the expired-token sample as a named golden-case fixture]
 [reviewer: plan compliance PASS]
 [/simplify: flagged unused error type export from old token.ts re-export. Removed.]
 [runs full test suite]
@@ -214,6 +215,8 @@ Claude: Starting Phase 3: Fix refresh token bug + cleanup
 Phase 3 complete:
 - [x] Refresh token bug fixed (rejects expired tokens before refreshing)
 - [x] Regression test: expired token refresh returns 401
+- [x] Golden-case fixture: expired token sample preserved for future
+  validation
 - [x] src/utils/token.ts deleted
 - [x] No dead imports remaining
 - [x] /simplify: 1 fix applied (stale re-export cleanup)
@@ -272,3 +275,8 @@ Refactoring is the riskiest type of change for AI agents. Without structure:
 - No phased approach means there's no safe rollback point. With RPI, after Phase 1, the old code still works. After Phase 2, you can verify the migration before removing anything. Phase 3 is just cleanup — the risky work is already done.
 
 The research document is especially valuable here. It becomes a map of the territory you're refactoring. If the map is wrong, throw it out and research again — that's 5 minutes. If the refactor is wrong, you're reverting commits and starting over — that's hours.
+
+When a bug like the refresh-token expiry issue has enough blast radius
+or enough recurrence history, don't stop at "we fixed it once." Promote
+it into a regression test plus a golden-case fixture so future validate
+or triage passes have a concrete sample to check.

--- a/methodology/README.md
+++ b/methodology/README.md
@@ -18,3 +18,8 @@
 ## The One-Paragraph Summary
 
 Every significant change goes through four phases: **Research** (understand the codebase as-is), **Plan** (create a phased implementation spec), **Implement** (execute one phase at a time with review gates), **Validate** (verify implementation against the plan). Each phase runs in its own conversation to manage context. Errors amplify downstream — a bad line of research becomes thousands of bad lines of code — so human review is focused on research and plans, not generated code.
+
+Before choosing a command, route the task by effort level:
+`quick` for short orientation, `standard` for normal RPI work, `deep`
+for high-ambiguity investigation or audits, and `batch` for explicitly
+independent plan phases that can run in parallel.

--- a/methodology/agent-design.md
+++ b/methodology/agent-design.md
@@ -69,6 +69,19 @@ This means:
 6. **Wait for ALL agents** before synthesizing.
 7. **Verify subagent results** — if something seems off, spawn a follow-up.
 
+## Routing Modes and Agent Depth
+
+The routing model controls how much orchestration to bring in:
+
+- `quick` — no team build-out; one lightweight orientation pass is enough
+- `standard` — normal RPI orchestration with targeted subagents and one
+  reviewer
+- `deep` — heavier parallel research or specialist audit coverage before
+  decisions are made
+- `batch` — multiple independent execution units in isolated worktrees
+
+This keeps "how many agents?" tied to task shape instead of habit.
+
 ---
 
 ## Subagent Catalog
@@ -583,7 +596,7 @@ Classify every action by its risk level to determine autonomy:
 |--------|----------|----------|
 | **Read-only** | Searching code, reading files, running tests, `git status`, `git log` | Fully autonomous |
 | **Low** | Writing code per approved plan, creating branches, committing to feature branches | Fully autonomous |
-| **Medium** | Pushing to `develop`, creating PRs, running `npm install` | Autonomous with post-action verification |
+| **Medium** | Pushing to the active development branch, creating PRs, running `npm install` | Autonomous with post-action verification |
 | **High** | Merging PRs, pushing to `main`/production, deploying, modifying external services | Human-gated — always ask first |
 | **Critical** | Deleting branches, force-pushing, dropping databases, modifying CI/CD pipelines | Human-gated — explain consequences before asking |
 
@@ -596,10 +609,10 @@ Classify every action by its risk level to determine autonomy:
 | Writing code per approved plan | Yes | Plan was already human-approved |
 | Creating git branches | Yes | Reversible, local scope |
 | Committing to feature branches | Yes | Reversible, local scope |
-| Pushing to `develop` | Yes, with CI monitor | Medium risk; background agent verifies |
+| Pushing to the active development branch | Yes, with CI monitor | Medium risk; background agent verifies |
 | Creating PRs | Yes | PR creation is proposing, not acting |
 | Adding PR descriptions | Yes | Informational, not destructive |
-| Merging PRs to `develop` | Ask first | Affects shared branch |
+| Merging PRs to the active development branch | Ask first | Affects shared branch |
 | Merging PRs to `main`/production | Always ask | Affects production |
 | Deploying to any environment | Always ask | External side effects |
 | Modifying CI/CD workflows | Always ask | Affects all contributors |

--- a/methodology/ci-and-guardrails.md
+++ b/methodology/ci-and-guardrails.md
@@ -78,6 +78,20 @@ The current guard script enforces:
 - **Error #33**: `git pull --rebase` with uncommitted changes (checks `git status --porcelain`)
 - **Error #44**: `git push --tags` instead of specific tag names (pattern match)
 
+### Hooks vs Verifiers vs Golden Cases
+
+Not every recurring failure belongs in a hook.
+
+| Promotion target | Best for | Example |
+|------------------|----------|---------|
+| **Hook** | bad actions detectable before execution | block `git pull --rebase` on a dirty tree |
+| **Scripted verifier** | bad states detectable after code changes | smoke-test a critical route during `/validate` |
+| **Golden-case fixture** | fragile behavior that needs a durable regression sample | known expired token, known malformed payload |
+
+The escalation path should stay continuous:
+logs -> rule -> hook or verifier -> golden-case fixture when a reusable
+example is the strongest protection.
+
 ### Three-Tier Error Prevention Model
 
 | Tier | Mechanism | Reliability | When to Use |
@@ -86,7 +100,12 @@ The current guard script enforces:
 | **Prompt** | Command recipes in CLAUDE.md | Medium — agent copies the pattern | Frequent operations. Give compound commands to copy instead of compose. |
 | **Document** | agent-errors.md, quick-reference.md | Low — advisory only | Long tail. Reference for when things go wrong. |
 
-Rules graduate upward: a pattern documented in tier 3 that keeps recurring gets promoted to tier 2 (recipe in CLAUDE.md) or tier 1 (hook). The error processing routine should track repeat offenders across batches and promote accordingly.
+Rules graduate upward: a pattern documented in tier 3 that keeps
+recurring gets promoted to tier 2 (recipe in CLAUDE.md) or tier 1
+(hook). When the pattern is better caught after implementation than
+before execution, promote it to a scripted verifier or a golden-case
+fixture instead. The error processing routine should track repeat
+offenders across batches and promote accordingly.
 
 Skills can extend this model with **on-demand hooks** — guardrails that activate only when a specific skill is invoked and last for the session. Use these for rules too restrictive to run permanently but essential in certain contexts (e.g., blocking destructive commands when touching production). See [agent-design.md](agent-design.md) "On-Demand Hooks" for examples.
 

--- a/methodology/context-engineering.md
+++ b/methodology/context-engineering.md
@@ -129,11 +129,22 @@ Aim to keep context utilization at **40-60%** of the window. Above 60%, output q
 
 This is why the RPI phases are separate conversations, not one long session.
 
-## Research on Main, Implement in Worktrees
+## Research on the Default Branch, Implement in Worktrees
 
-Research and planning should happen on the `main`/`develop` branch — they don't modify code, so there's no risk. Implementation should happen in a git worktree or feature branch, keeping the default branch clean. This also means multiple research/planning sessions can happen in parallel without conflicts.
+Research and planning should happen on the project's default integration
+branch — in many projects this is `main`, while branch-based release
+workflows may use `develop` or another integration branch. These phases
+don't modify code, so there's no risk. Implementation should happen in
+a git worktree or feature branch, keeping the default integration
+branch clean. This also means multiple research/planning sessions can
+happen in parallel without conflicts.
 
 In Claude Code: use the `/worktree` command or `EnterWorktree` tool when starting implementation.
+
+This branch split also lines up with the routing model: `quick` and
+`deep` work usually stay on the default integration branch because they
+orient, investigate, or audit. `standard` and `batch` work move into
+isolated implementation environments before edits begin.
 
 ## Multiple Research Passes
 

--- a/methodology/error-success-logging.md
+++ b/methodology/error-success-logging.md
@@ -96,14 +96,71 @@ Maintain a `docs/logs/README.md` with one-line lessons extracted from each log e
 - **Before `/research`**: Read the lessons index to prime the agent with known patterns.
 - **Before `/plan`**: Check if similar features had error logs — avoid repeating mistakes.
 - **After a session goes wrong**: Write the error log before closing the session, while context is fresh.
-- **Periodically**: Review the index for recurring patterns. If you see 3+ entries about the same category, add a rule to CLAUDE.md or `patterns/quick-reference.md`.
+- **During `/triage`**: Review carried items and repeated findings. If the
+  same pattern keeps reappearing, propose a promotion destination.
+- **Periodically**: Review the index for recurring patterns. If you see
+  3+ entries about the same category, promote the pattern beyond prose.
 
-### Graduating Logs to Rules
+### Promotion Destinations
 
-When a pattern appears 3 or more times in your logs:
-1. Extract it as a rule in CLAUDE.md or `patterns/quick-reference.md`
-2. Add a detailed entry to `patterns/agent-errors.md` if it's a Claude Code error
-3. The log entries remain as historical evidence, but the rule becomes the primary reference
+When a pattern appears 3 or more times, keep the logs as evidence but
+promote the pattern into the smallest executable asset that will
+actually prevent or detect it.
+
+| Destination | Use it when | Outcome |
+|-------------|-------------|---------|
+| **Rule** | The pattern needs judgment and is not cleanly machine-detectable | Add or update `CLAUDE.md` or `patterns/quick-reference.md` |
+| **Hook** | The bad action is mechanically detectable before it executes | Block it with a PreToolUse or related hook |
+| **Scripted verifier** | The failure must be checked repeatedly during validation or triage | Add a deterministic command, smoke check, or inspection script |
+| **Golden-case fixture** | The behavior needs a reusable regression example with known-good input/output | Add a test fixture or representative sample case that must keep passing |
+
+### Choosing the Right Promotion
+
+Ask these questions in order:
+
+1. Can a script detect the bad action before it happens?
+   If yes, promote to a **hook**.
+2. Can a script detect the bad state after implementation or during
+   validation?
+   If yes, promote to a **scripted verifier**.
+3. Does the repeated issue come from a fragile behavior that needs a
+   stable example?
+   If yes, promote to a **golden-case fixture**.
+4. If none of the above fit, promote to a **rule** and keep watching.
+
+### Promotion Flow
+
+1. Log the error or success normally.
+2. Add the one-line lesson to `docs/logs/README.md`.
+3. When the same pattern repeats 3+ times, choose a promotion
+   destination.
+4. Record the promotion in the next triage cycle so it becomes part of
+   operational history.
+5. Keep the original logs as evidence for why the rule, hook, verifier,
+   or fixture exists.
+
+### Example Promotion Outcomes
+
+- Repeated dirty `git pull --rebase` attempts:
+  logs -> quick-reference rule -> hook block in `guard-bash.sh`
+- Repeated "tests passed locally but critical route still broken":
+  logs -> scripted verifier that curls the route during validation
+- Repeated refresh-token expiry regressions:
+  logs -> regression test plus a golden-case expired-token fixture
+- Repeated vague planning prompts that cannot be machine-detected:
+  logs -> stronger planning rule in `patterns/quick-reference.md`
+
+### Promotion and Triage
+
+`/triage` is where promotions become operational. Triage should identify
+repeated carried items, recommend the destination, and make the outcome
+visible in shared operational history.
+
+### Detailed Error Catalog
+
+If the repeated pattern is an agent or harness failure, also add or
+update the longer explanation in `patterns/agent-errors.md`. The short
+rule teaches the behavior; the catalog preserves the deeper why.
 
 ### Compression Over Time
 

--- a/methodology/four-phases.md
+++ b/methodology/four-phases.md
@@ -36,6 +36,27 @@ User
 - **Separation of concerns**: Locators find *where* things are. Analyzers explain *how* things work. Pattern finders show *examples*. They don't overlap.
 - **Phase gates**: Implementation stops between phases. Validation is a separate explicit step.
 
+## Routing Before Command Selection
+
+Routing is a front-door choice, not a second workflow. Pick the effort
+mode first, then choose the command that already implements it.
+
+| Mode | Use it when | Typical command surface |
+|------|-------------|-------------------------|
+| `quick` | Ambiguity is low, blast radius is small, the step is easily reversible, and you mainly need orientation | `/status` |
+| `standard` | The task fits the normal RPI path and should move through research, plan, implement, and validate with review gates | `/plan`, `/implement`, `/validate` after the relevant handoff |
+| `deep` | Ambiguity is high, blast radius is unclear, reversibility is poor without more investigation, or verification is hard | `/research`, `/pre-launch` |
+| `batch` | Work is already planned and the remaining phases are explicitly marked `[batch-eligible]` | `/batch` via `/implement` |
+
+Use these intake questions:
+
+1. How ambiguous is the task right now?
+2. What is the blast radius if we guess wrong?
+3. How reversible is the next step?
+4. How hard will verification be if we skip deeper investigation?
+
+If the answers drift upward, route deeper before writing code.
+
 ### Mapping to Claude Code
 
 | Concept | Claude Code Equivalent |
@@ -232,6 +253,7 @@ Research is **NOT done** if:
 4. **Detailed plan writing:**
    - Write main plan file + separate file per phase.
    - Use pseudocode notation (see [pseudocode-notation.md](pseudocode-notation.md)).
+   - Add a compact verifier section to each phase file.
    - Separate automated vs. manual success criteria.
    - Maximum 3 `[NEEDS CLARIFICATION]` markers; resolve all before finalizing.
 
@@ -250,6 +272,7 @@ Research is **NOT done** if:
 A plan is **done** when:
 - [ ] Every phase has specific files to create/modify (no "update relevant files")
 - [ ] Every phase has automated success criteria with exact commands to run
+- [ ] Every phase file has a verifier section with target behavior, checks, setup, edge conditions, and allowed manual exceptions
 - [ ] Pseudocode notation is used for non-trivial logic changes
 - [ ] The scope exclusion list is explicit ("NOT doing: ...")
 - [ ] Zero `[NEEDS CLARIFICATION]` markers remain
@@ -340,12 +363,13 @@ An implementation phase is **NOT done** if:
 **Process:**
 
 1. Locate the plan (provided or discovered via git log).
-2. Gather evidence: git log, git diff, run test suites.
+2. Gather baseline evidence: git log, git diff, existing verification output, and any artifacts referenced by the verifier.
 3. For each phase:
    - Verify completion status matches reality.
-   - Run every automated verification command.
-   - Assess manual criteria.
-   - Think about edge cases.
+   - Read the phase verifier and check target behavior against the codebase state.
+   - Run every automated verification command listed in the verifier.
+   - Assess fixtures, setup assumptions, and manual exceptions.
+   - Check listed edge cases.
 4. Generate a validation report.
 
 **Validation report structure:**
@@ -360,6 +384,11 @@ An implementation phase is **NOT done** if:
 ### Automated Verification Results
 - [x] Build passes
 - [ ] Linting issues (details)
+
+### Verifier Results
+- Phase 1 target behavior: [met / not met]
+- Phase 1 setup assumptions: [matched / mismatched]
+- Phase 1 edge cases: [covered / missing]
 
 ### Code Review Findings
 #### Matches Plan
@@ -376,6 +405,7 @@ An implementation phase is **NOT done** if:
 
 Validation is **done** when:
 - [ ] Every plan phase has been checked against the actual code
+- [ ] Every phase verifier has been read and checked against the implementation
 - [ ] All automated verification commands have been run and results recorded
 - [ ] Deviations from the plan are documented with explanations
 - [ ] The validation report is complete with a clear verdict

--- a/methodology/push-accountability.md
+++ b/methodology/push-accountability.md
@@ -1,6 +1,7 @@
 # Push Accountability
 
-> Every push to the development branch requires CI verification. No exceptions. No matter how small the change.
+> Every push to the branch under active development requires CI
+> verification. No exceptions. No matter how small the change.
 
 ## The Problem
 
@@ -8,16 +9,18 @@ Without push accountability, the most common failure mode is "push and forget" �
 
 ## The Protocol
 
-After ANY push to the development branch, the agent must verify that CI passes. This happens as a **background task** so the main terminal stays unblocked.
+After ANY push to the branch under active development, the agent must
+verify that CI passes. This happens as a **background task** so the
+main terminal stays unblocked.
 
 ### Sequence
 
 ```
-1. Agent pushes to develop
+1. Agent pushes to the active development branch
    └─> Immediately spawns a background verification agent
 
 2. Background agent polls CI status
-   └─> gh run list --branch develop --limit 5
+   └─> gh run list --branch <active-branch> --limit 5
    └─> Repeat every 30-60 seconds until the run completes
 
 3a. CI passes
@@ -47,7 +50,7 @@ In Claude Code, this maps to `Task` with `run_in_background: true`:
 Task(
   subagent_type="Bash",
   run_in_background=true,
-  prompt="Monitor CI for the latest push to develop. Poll gh run list --branch develop --limit 1 every 30 seconds until it completes. If it fails, run gh run view <id> --log-failed, diagnose the issue, fix it, and push again. If it passes, report success. Never push to main."
+  prompt="Monitor CI for the latest push to the active development branch. Poll gh run list --branch <active-branch> --limit 1 every 30 seconds until it completes. If it fails, run gh run view <id> --log-failed, diagnose the issue, fix it, and push again. If it passes, report success. Never push to the production branch."
 )
 ```
 
@@ -56,7 +59,8 @@ Task(
 1. **Every push gets a monitor.** No exceptions. Even single-line changes can break CI if they affect types, imports, or test fixtures.
 2. **Background, not blocking.** The main terminal continues working on the next task immediately. The background agent owns the push outcome.
 3. **Fix and re-push.** If CI fails, the background agent fixes the issue and pushes again. It doesn't report back and wait — it acts.
-4. **Never touch production.** Even if a fix seems urgent, background agents only operate on the development branch.
+4. **Never touch production.** Even if a fix seems urgent, background
+   agents only operate on the active development branch.
 5. **Conflict awareness.** If the background fix requires changes that conflict with the main terminal's current work, notify the user before applying.
 6. **Retry budget.** If CI fails 3 times after 3 fix attempts, the background agent stops and reports the issue clearly.
 
@@ -74,7 +78,7 @@ Common CI failure categories and how to investigate:
 
 ```bash
 # Investigation commands:
-gh run list --branch develop --limit 3 --json conclusion,status,name,databaseId
+gh run list --branch <active-branch> --limit 3 --json conclusion,status,name,databaseId
 gh run view <run-id> --log-failed 2>&1 | tail -100
 ```
 
@@ -115,7 +119,8 @@ Instead of fixing failures sequentially, spawn parallel fix agents — one per f
 2. **Fix agents read both the test and the source.** A fix agent that only reads the error message will produce shallow fixes. It must understand the intent of the failing test.
 3. **Run the full suite after combining fixes.** Individual fix agents verify their own changes, but the combined result may introduce new failures. Always run a full verification pass.
 4. **Retry budget: 3 cycles.** If the suite isn't green after 3 fix-and-verify cycles, stop and report what remains broken. Infinite loops are worse than a failing CI.
-5. **Never push to production from a fix loop.** Self-healing operates on the development branch only.
+5. **Never push to production from a fix loop.** Self-healing operates
+   on the active development branch only.
 
 ### Slash Command
 

--- a/methodology/scheduled-agents.md
+++ b/methodology/scheduled-agents.md
@@ -97,6 +97,12 @@ The `# SCHEDULE:` comment is read by `install-agents.sh` to auto-generate launch
 
 The `install-agents.sh` script (in `templates/scripts/agents/`) auto-discovers agent scripts and generates launchd plists. It reads the `# SCHEDULE:` comment from each script to determine when it runs.
 
+For bundle-local setup and verification, keep the colocated manifests
+next to the reusable bundle:
+
+- `templates/scripts/agents/INSTALL.md`
+- `templates/scripts/agents/VERIFY.md`
+
 ```bash
 # Install all agents (auto-discovers scripts with SCHEDULE comments):
 bash scripts/agents/install-agents.sh

--- a/methodology/testing.md
+++ b/methodology/testing.md
@@ -36,6 +36,33 @@ Always separate into two sections:
 - [ ] [Step] — WHY manual: [requires sudo / hardware / visual-only]
 ```
 
+## Verification Contract
+
+Each plan phase should also define a compact **Verifier** section that
+`/validate` can consume directly.
+
+```markdown
+### Verifier
+
+- **Target behavior:** What should be true when the phase is complete
+- **Automated checks:** Exact commands or inspections to run
+- **Fixtures / data / setup:** Required inputs, seed data, or environment assumptions
+- **Failure cases / edge conditions:** Specific cases the validator should inspect
+- **Allowed manual exceptions:** Only the checks that truly cannot be automated, with WHY
+```
+
+The verifier is not a replacement for success criteria. It is the
+compact contract that tells the validator what evidence to gather and
+how to judge the phase.
+
+When a repeated failure survives prose-only guidance, strengthen the
+verifier with an executable check:
+
+- add a **scripted verifier** when a command or inspection can detect
+  the failure reliably
+- add a **golden-case fixture** when the behavior needs a stable sample
+  input/output pair or regression scenario
+
 ## TDD Protocol
 
 Test-Driven Development is mandatory for all code changes. No exceptions — not even "small" changes.
@@ -53,6 +80,9 @@ Test-Driven Development is mandatory for all code changes. No exceptions — not
 - **Refactors need existing tests.** Before refactoring, ensure tests cover the current behavior. If they don't, write them first.
 - **No "I'll add tests later."** There is no later. Tests are written in the same worktree, in the same commit sequence, before the implementation.
 - **Tests are the spec.** A failing test IS the specification for what the code should do. Write the test as if the feature already works, then make it true.
+- **Repeated regressions should become golden cases.** If the same class
+  of bug keeps returning, preserve the reproducer as a named fixture or
+  representative sample, not just an ad hoc one-off test.
 
 ### In the RPI Workflow
 
@@ -64,6 +94,10 @@ TDD integrates into the Implement phase:
 5. Stop and wait for human review
 
 The tests written in step 2 become the automated verification for the phase.
+
+The phase verifier records the same intent in a compact, reusable
+format so `/validate` can check the implementation against the plan
+instead of relying on generic verification wording.
 
 ## Phase Completion Protocol
 

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": [
+    "CLAUDE.md",
+    ".claude/rules/*.md"
+  ]
+}

--- a/patterns/agent-errors.md
+++ b/patterns/agent-errors.md
@@ -1,6 +1,6 @@
 # Known Agent Errors -- Universal Catalog
 
-63 documented error patterns from real recurring issues across projects.
+64 documented error patterns from real recurring issues across projects.
 Each entry: symptom, root cause, correct approach, anti-pattern.
 
 **Note:** This file is the source of truth for error patterns. The condensed
@@ -2332,3 +2332,39 @@ pytest -x --numprocesses=2
 ```
 
 **Key detail:** This compounds with Error #1 — if any agent's test run fails, sibling tool calls are killed, but the underlying test processes (spawned via Bash) continue running. The agent loses the ability to manage or cancel them. Prevention is the only fix: scope tests narrowly and limit concurrency.
+
+---
+
+## Error #64: Repeated failure documented, but never promoted to an executable check
+
+**Symptom:** The same issue appears in logs, reports, or postmortems
+multiple times. Everyone "knows" the lesson, but the harness still
+relies on memory and prose, so the failure keeps resurfacing.
+
+**Root cause:** The team stopped at documentation. The pattern was real,
+repeatable, and costly, but never graduated into a rule, hook, scripted
+verifier, or golden-case fixture.
+
+**Correct approach — always do this:**
+```text
+1. Keep the logs as evidence.
+2. After 3 recurrences, choose a promotion target:
+   - rule for judgment-heavy guidance
+   - hook for mechanically detectable bad actions
+   - scripted verifier for repeatable validation checks
+   - golden-case fixture for fragile regressions or known-good samples
+3. Record the promotion during triage so it becomes operational history.
+```
+
+**Never do this:**
+```text
+- "Let's just remember this next time."
+- "It's already in the wiki, so we're covered."
+- Adding another prose note when the failure is script-detectable.
+```
+
+**Examples:**
+- Dirty `git pull --rebase` attempts -> hook
+- Critical route keeps breaking despite green tests -> scripted verifier
+- Refresh-token expiry bug keeps returning -> regression test with
+  golden-case expired-token fixture

--- a/patterns/deployment-safety.md
+++ b/patterns/deployment-safety.md
@@ -30,7 +30,9 @@ This means:
 
 - **Dependabot PRs target `main` by default.** Merging them deploys to production immediately.
 - **"Clean up the PRs" means close or retarget them** — not merge them to production.
-- **The correct workflow for Dependabot:** cherry-pick updates to `develop`, close the Dependabot PR, release via the normal `develop` -> `main` process.
+- **The correct workflow for Dependabot:** cherry-pick updates to your
+  integration branch, close the Dependabot PR, and release through the
+  project's normal integration -> production process.
 - **"Merge the PRs" is never authorization to deploy to production** unless the user explicitly says "deploy to production" or "merge to main."
 
 ---
@@ -126,9 +128,9 @@ Once production is stable on the rollback:
 
 **Never promote a broken deployment "briefly" to capture logs.** That causes another outage. Use the platform's log retention, or deploy to a preview URL to reproduce the error.
 
-### Step 3: Fix Forward on `develop`
+### Step 3: Fix Forward on the Integration Branch
 
-1. Create the fix on `develop` (or a feature branch)
+1. Create the fix on the integration branch (or a feature branch)
 2. Test locally
 3. Deploy to a preview URL and verify
 4. Only after preview verification, create a PR to `main`
@@ -190,13 +192,15 @@ Agent merges 7 Dependabot PRs one-by-one. Each merge invalidates checks on remai
 
 Agent told to "clean up Dependabot PRs." Interprets this as "merge them." Dependabot PRs target `main`. Each merge triggers a production deployment. One dependency has a production-only bug. Site goes down.
 
-**Fix:** Understand that merging to `main` = deploying to production. Cherry-pick updates to `develop` instead.
+**Fix:** Understand that merging to `main` = deploying to production.
+Cherry-pick updates to the integration branch instead.
 
 ### The Panic Recovery
 
 Production is down. Agent promotes the broken deployment "briefly" to capture logs — site goes down again. Deploys maintenance mode with TypeScript errors — fails. Deploys again with env var issues — fails. Each failed attempt is another billed deployment and another outage window.
 
-**Fix:** Roll back immediately. Investigate on non-production. Fix forward on `develop`. Never improvise recovery.
+**Fix:** Roll back immediately. Investigate on non-production. Fix
+forward on the integration branch. Never improvise recovery.
 
 ### The Untested Framework Upgrade
 
@@ -217,6 +221,6 @@ Agent merges Next.js minor version bump after CI passes. Build succeeds, tests p
 | Assess risk | Framework upgrades need preview verification; dev patches need CI only |
 | Preview before prod | Deploy to preview URL and verify before merging to `main` |
 | Roll back first | When production is down, restore service before investigating |
-| Fix forward | Create fixes on `develop`, verify on preview, then release to `main` |
+| Fix forward | Create fixes on the integration branch, verify on preview, then release to `main` |
 | Count the cost | Track CI runs and deployments — stop if exceeding estimates |
 | Local first | Test locally before pushing; build locally before deploying |

--- a/patterns/quick-reference.md
+++ b/patterns/quick-reference.md
@@ -171,6 +171,10 @@ Skills: `[skill:name]` points to `.claude/skills/name/` for full examples.
 
 71. **Use timestamp-based discovery for triage** `[frequent]` -- touch `docs/agents/.last-triage` after each run. Next triage uses `find ... -newer .last-triage`. On first run, process all reports.
 
+74. **Promote repeated failures beyond prose** `[frequent]` -- after 3
+recurrences, choose the smallest durable asset: rule, hook, scripted
+verifier, or golden-case fixture.
+
 ---
 
 For detailed symptoms, root causes, and examples, see [agent-errors.md](agent-errors.md).

--- a/templates/AGENTS.md.template
+++ b/templates/AGENTS.md.template
@@ -1,23 +1,42 @@
 # Project: [PROJECT NAME]
 
-## Codex Compatibility
+## Codex and OpenCode Compatibility
 
 This project follows the cc-rpi methodology and is configured to work
-with both Claude Code and Codex / GPT-5.x.
+with Claude Code, Codex / GPT-5.x, and OpenCode.
 
-When operating in Codex, treat these files as the source of truth:
+When operating in Codex or OpenCode, treat these files as the source of
+truth:
 
 - `CLAUDE.md` -- project overview, workflow, commands, git/deploy context
 - `.claude/commands/*.md` -- workflow definitions for `/research`, `/plan`,
   `/implement`, `/validate`, `/pre-launch`, `/update-docs`, `/release`,
   and related commands
+- `.opencode/commands/*.md` -- thin OpenCode wrappers that dispatch to
+  the canonical `.claude/commands/*.md` files without duplicating the
+  workflow logic
 - `.claude/rules/*.md` -- reusable rules and path-scoped constraints
 - `.claude/skills/*/SKILL.md` -- on-demand skills and domain procedures
+- `opencode.json` -- OpenCode instruction loading for `CLAUDE.md` and
+  `.claude/rules/*.md`
 
-If the user says "make this Codex compatible", ensure this file exists
-and is kept in sync with the compatibility conventions below.
+If the user says "make this Codex compatible" or "make this OpenCode
+compatible", ensure this file exists and is kept in sync with the
+compatibility conventions below.
 
 ## Command Dispatch
+
+Route the task before picking a command:
+
+- `quick` -- short orientation, low ambiguity, low blast radius,
+  reversible next step; usually `/status`
+- `standard` -- normal RPI delivery path with phase gates; usually
+  `/plan`, `/implement`, `/validate`
+- `deep` -- high ambiguity, unclear blast radius, hard verification, or
+  launch-readiness investigation; usually `/research` or `/pre-launch`
+- `batch` -- only after planning proves the remaining work is
+  independent and marked `[batch-eligible]`; executed through `/batch`
+  from `/implement`
 
 When the user invokes a slash-style workflow such as `/research`,
 `/plan`, `/implement`, `/validate`, `/pre-launch`, `/update-docs`,
@@ -31,10 +50,22 @@ When the user invokes a slash-style workflow such as `/research`,
 If the command file references a plan path or research path, read that
 document fully before doing anything else.
 
-## Claude-to-Codex Translation
+## OpenCode Command Dispatch
 
-The command files are written for Claude Code. In Codex, translate the
-Claude-native parts to the closest equivalent behavior:
+When the user invokes a slash-style workflow in OpenCode:
+
+1. Check for the matching file in `.opencode/commands/`.
+2. Read that command file completely before acting.
+3. Treat it as a wrapper that points back to the canonical
+   `.claude/commands/<name>.md` workflow spec.
+4. Preserve the existing slash command names; do not fork the command
+   logic into separate OpenCode-only workflow files unless the command
+   surface itself must change.
+
+## Claude-to-Codex/OpenCode Translation
+
+The command files are written for Claude Code. In Codex or OpenCode,
+translate the Claude-native parts to the closest equivalent behavior:
 
 - `/simplify` -- if `codex-simplify` is installed, use it; otherwise run
   a dedicated post-implementation review for reuse, quality, and
@@ -82,6 +113,9 @@ Treat `.claude/skills/*/SKILL.md` as on-demand skills:
 
 Personal Codex-only skills may also exist in `~/.codex/skills/`.
 Use them only when they do not shadow Claude-native command names.
+
+OpenCode also discovers project skills in `.claude/skills/` and can
+load `CLAUDE.md` plus `.claude/rules/*.md` through `opencode.json`.
 
 ## Outputs and Gates
 

--- a/templates/CLAUDE.md.template
+++ b/templates/CLAUDE.md.template
@@ -33,7 +33,14 @@ pnpm run build          # Production build
 
 ## Git Workflow
 
-**`develop` is the default branch. `main` is production.**
+**Adapt this section to your project's branch strategy.**
+
+Common patterns:
+
+- Branch-based release flow: `develop` (or another integration branch)
+  is the default working branch and `main` is production
+- Main-only flow: `main` is both the default and production branch,
+  usually with tagged releases
 
 Conventional commits:
 `feat|fix|test|refactor|chore|docs(scope): description`

--- a/templates/commands/INSTALL.md
+++ b/templates/commands/INSTALL.md
@@ -1,0 +1,44 @@
+# Commands Bundle — INSTALL
+
+This bundle is the canonical slash-command set for cc-rpi projects.
+
+## Prerequisites
+
+- A project with `.claude/commands/`
+- For OpenCode compatibility, also create `.opencode/commands/`
+- `AGENTS.md` should tell Codex/OpenCode to treat
+  `.claude/commands/*.md` as the workflow source of truth
+
+## Install Steps
+
+1. Copy the command files you want from `templates/commands/` into the
+   target project's `.claude/commands/`.
+2. For project bootstrap/adopt/update/detach at user level, install
+   those commands into `~/.claude/commands/` instead of the project.
+3. Adjust any project-specific paths or stack-specific command details.
+4. If the project supports OpenCode, copy the matching wrappers from
+   `templates/opencode/commands/`.
+
+## Bundle Scope
+
+Common project-level commands:
+
+- `research.md`
+- `plan.md`
+- `implement.md`
+- `validate.md`
+- `describe-pr.md`
+- `pre-launch.md`
+- `remediate.md`
+- `triage.md`
+- `status.md`
+- `fix-ci.md`
+- `update-docs.md`
+- `release.md`
+
+Blueprint lifecycle commands that usually live in `~/.claude/commands/`:
+
+- `bootstrap.md`
+- `adopt.md`
+- `update.md`
+- `detach.md`

--- a/templates/commands/VERIFY.md
+++ b/templates/commands/VERIFY.md
@@ -1,0 +1,39 @@
+# Commands Bundle — VERIFY
+
+Use this after installing the command bundle into a project.
+
+## Verify Canonical Command Files
+
+Check that the target project contains the expected files in
+`.claude/commands/`, especially:
+
+- `research.md`
+- `plan.md`
+- `implement.md`
+- `validate.md`
+
+## Verify Workflow Ownership
+
+Confirm the project's `AGENTS.md` and `CLAUDE.md` still point agents to
+`.claude/commands/` as the workflow spec.
+
+## Verify OpenCode Wrappers
+
+If the project uses OpenCode:
+
+1. Confirm matching files exist in `.opencode/commands/`.
+2. Confirm each wrapper points back to the canonical
+   `.claude/commands/<name>.md` file instead of duplicating workflow
+   logic.
+
+## Verify Project Fit
+
+- command paths match the project's actual `docs/` layout
+- stack-specific commands (test/lint/build) reflect the target project
+- no project-specific command was overwritten unintentionally
+
+## Manual Exceptions
+
+- User-level lifecycle commands (`bootstrap`, `adopt`, `update`,
+  `detach`) are verified in `~/.claude/commands/`, not in a project
+  repo.

--- a/templates/commands/adopt.md
+++ b/templates/commands/adopt.md
@@ -14,8 +14,11 @@ Read these files from cc-rpi IN ORDER. Do not skip any.
 The error-patterns skill provides condensed error reference on demand. The full catalog (`patterns/agent-errors.md`) is available but not required for onboarding.
 3. `templates/setup-checklist.md` — Understand the target state for a fully set up project.
 4. `templates/CLAUDE.md.template` — Know what a well-configured CLAUDE.md looks like.
-5. `templates/AGENTS.md.template` — Know what the Codex compatibility layer should contain.
+5. `templates/AGENTS.md.template` — Know what the Codex/OpenCode compatibility layer should contain.
 6. `templates/settings.json.template` — Know what settings.json should contain.
+7. `templates/opencode.json.template` — Know how OpenCode should load instructions.
+8. `templates/commands/INSTALL.md` and `templates/commands/VERIFY.md` — Know the local command-bundle install and verification expectations.
+9. `templates/scripts/agents/INSTALL.md` and `templates/scripts/agents/VERIFY.md` — Know the local scheduled-agent install and verification expectations when those bundles are adopted.
 
 ## Phase 2: Audit This Project
 
@@ -24,8 +27,10 @@ Now investigate THIS project. Spawn parallel Explore agents to assess the curren
 **Agent 1 — Configuration Audit:**
 - Does CLAUDE.md exist? If so, read it fully. How complete is it vs the template?
 - Does AGENTS.md exist? If so, read it fully. Does it bridge Codex to the existing `.claude/*` structure?
+- Does `opencode.json` exist? If so, does it load `CLAUDE.md` and `.claude/rules/*.md`?
 - Does `.claude/settings.json` exist? What permissions and env vars are configured?
 - Does `.claude/commands/` exist? Which slash commands are present?
+- Does `.opencode/commands/` exist? Which wrapper commands are present?
 - Does `.claude/skills/` exist? Which skills are installed?
 - Does `.claude/rules/` exist? Which rules are installed? (New in blueprint v2)
 - Does `.claude/agents/` exist?
@@ -62,6 +67,7 @@ List gaps organized by priority:
 **HIGH — Core workflow (blocks effective RPI usage):**
 - Missing or incomplete CLAUDE.md
 - Missing or incomplete AGENTS.md Codex compatibility layer
+- Missing `opencode.json` or missing `.opencode/commands/` OpenCode compatibility layer
 - No slash commands for /research, /plan, /implement, /validate
 - No settings.json or Agent Teams not enabled
 - No docs/ directory structure
@@ -92,11 +98,12 @@ List things that exist but differ from the blueprint. For each, explain the gap 
 Propose a phased order for the migration. Always start with the highest-leverage items:
 1. CLAUDE.md (affects every session)
 2. AGENTS.md (makes the same workflow operable in Codex)
-3. settings.json + Agent Teams (affects Claude agent capabilities)
-4. Slash commands (affects daily workflow)
-5. docs/ directory structure (affects research/plan storage)
-6. Pre-commit hooks and CI (affects quality enforcement)
-7. Logging, scheduled agents (polish)
+3. opencode.json + `.opencode/commands/` (makes the same workflow operable in OpenCode)
+4. settings.json + Agent Teams (affects Claude agent capabilities)
+5. Slash commands (affects daily workflow)
+6. docs/ directory structure (affects research/plan storage)
+7. Pre-commit hooks and CI (affects quality enforcement)
+8. Logging, scheduled agents (polish)
 
 ## Phase 4: Get Approval and Execute
 
@@ -107,17 +114,21 @@ After presenting the report:
 3. **Create a migration plan** as a checklist based on their decisions.
 4. **Execute the plan item by item**, confirming after each major change.
 5. **Create or update `AGENTS.md`** — adapt from `cc-rpi/templates/AGENTS.md.template`:
-   - Point Codex at `CLAUDE.md`, `.claude/commands/`, `.claude/rules/`, and `.claude/skills/`
-   - Preserve any project-specific Codex notes already present
-   - Unless the user explicitly opts out, always make the adopted project Codex compatible
-   - If the user says "make this Codex compatible", treat that as explicit approval to create or repair this layer
-6. **Install `.claude/rules/`** — copy rule templates from `cc-rpi/templates/rules/`:
+   - Point Codex and OpenCode at `CLAUDE.md`, `.claude/commands/`, `.claude/rules/`, and `.claude/skills/`
+   - Preserve any project-specific compatibility notes already present
+   - Unless the user explicitly opts out, always make the adopted project Codex/OpenCode compatible
+   - If the user says "make this Codex compatible" or "make this OpenCode compatible", treat that as explicit approval to create or repair this layer
+6. **Create or update `opencode.json` and `.opencode/commands/`**:
+   - Adapt from `cc-rpi/templates/opencode.json.template`
+   - Copy wrapper commands from `cc-rpi/templates/opencode/commands/`
+   - Keep wrappers thin so `.claude/commands/` remains the workflow source of truth
+7. **Install `.claude/rules/`** — copy rule templates from `cc-rpi/templates/rules/`:
    - Always: `rpi-details.md`, `push-accountability.md`
    - If deployment pipeline: `deployment-safety.md`
    - If Supabase: `supabase.md`
    - If tests: `testing.md`
    - Adapt `paths` in frontmatter to match the project's file structure.
-7. **Migrate `<important if>` blocks** — if the project's CLAUDE.md has `<important if>` blocks:
+8. **Migrate `<important if>` blocks** — if the project's CLAUDE.md has `<important if>` blocks:
    - Extract each block's content
    - Create a `.claude/rules/` file with `paths` frontmatter
    - Remove the block from CLAUDE.md
@@ -127,13 +138,14 @@ After presenting the report:
 
 After completing the migration:
 
-5. Save the following to auto memory so future sessions start with full awareness:
+1. Save the following to auto memory so future sessions start with full awareness:
     - Project name, type, and stack
     - What was already in place vs what was migrated
     - Key decisions made during adoption (what the user chose to keep, skip, or adapt)
     - Any project-specific conventions or constraints discovered during the audit
     - CI/CD pipeline behavior, deployment targets, environment quirks
-    - Whether the project is now Codex compatible via `AGENTS.md`
+    - Whether the project is now Codex/OpenCode compatible via
+      `AGENTS.md`, `opencode.json`, and `.opencode/commands/`
     - The operational rules and error patterns you internalized from Phase 1
 
 This ensures the next session doesn't start from zero — the agent already knows the project context, the rules, and the migration decisions.
@@ -151,7 +163,7 @@ This is optional but recommended — it gives adopters a clear picture of their 
 - **Audit first, change nothing.** Phase 2 and 3 are entirely read-only. No files are modified until the user approves the plan.
 - **Respect what exists.** This project has history. Don't overwrite working configurations without asking.
 - **Merge, don't replace.** If CLAUDE.md already exists with useful content, add the missing pieces — don't replace the whole file.
-- **Keep the methodology portable.** Unless the user opts out, add the Codex compatibility layer via `AGENTS.md`.
+- **Keep the methodology portable.** Unless the user opts out, add the Codex/OpenCode compatibility layer via `AGENTS.md`, `opencode.json`, and `.opencode/commands/`.
 - **Preserve project identity.** The project's name, description, stack choices, and conventions are theirs. The blueprint provides structure, not opinions about technology choices.
 - **Ask before assuming.** When in doubt about whether to change something, ask.
 - **Keep CLAUDE.md lean.** Target ~70 lines. Domain rules go in `.claude/rules/` and `.claude/skills/`, not CLAUDE.md.

--- a/templates/commands/bootstrap.md
+++ b/templates/commands/bootstrap.md
@@ -17,8 +17,11 @@ Read these files to understand what you'll be creating:
 
 3. `templates/setup-checklist.md` — This is your step-by-step guide. You'll execute it in Phase 3.
 4. `templates/CLAUDE.md.template` — The starting point for this project's CLAUDE.md.
-5. `templates/AGENTS.md.template` — The Codex compatibility layer for this project's AGENTS.md.
+5. `templates/AGENTS.md.template` — The Codex/OpenCode compatibility layer for this project's AGENTS.md.
 6. `templates/settings.json.template` — The starting point for .claude/settings.json.
+7. `templates/opencode.json.template` — OpenCode instruction loading for this project.
+8. `templates/commands/INSTALL.md` and `templates/commands/VERIFY.md` — Local install and verification notes for the command bundle.
+9. `templates/scripts/agents/INSTALL.md` and `templates/scripts/agents/VERIFY.md` — Local install and verification notes for the scheduled-agent bundle.
 
 ## Phase 3: Set Up This Project
 
@@ -27,38 +30,41 @@ Now execute the setup checklist against THIS project. Work through it section by
 1. **Ask me** what type of project this is (web app, library, CLI, monorepo, Python, static site) so you can adapt accordingly.
 2. **Ask me** for the project name, description, stack, and any specifics you need to fill in the templates.
 3. Create the CLAUDE.md — adapt from the template, manually crafting every line for this project's needs.
-4. Create the AGENTS.md — adapt from the template so Codex can follow this project's cc-rpi setup too.
+4. Create the AGENTS.md — adapt from the template so Codex and OpenCode can follow this project's cc-rpi setup too.
 5. Create `.claude/settings.json` — adapt from the template.
 6. Create `.claude/commands/` — copy slash commands from `cc-rpi/templates/commands/` and adjust file paths.
-7. Install skills from `cc-rpi/templates/skills/` to `.claude/skills/`:
+7. Create `.opencode/commands/` — copy wrapper commands from `cc-rpi/templates/opencode/commands/`.
+8. Create `opencode.json` — adapt from `cc-rpi/templates/opencode.json.template`.
+9. Install skills from `cc-rpi/templates/skills/` to `.claude/skills/`:
    - Always install: `git-workflow/`, `multi-agent/`, `deployment-safety/`, `ci-workflow/`, `github-cli/`, `error-patterns/`
    - If Python project: also install `python-rules/`
    - If macOS development: also install `macos-rules/`
    - If using Supabase: also install `supabase/`
    - Each skill is a directory with a SKILL.md file -- copy the entire directory.
-8. Install rules from `cc-rpi/templates/rules/` to `.claude/rules/`:
+10. Install rules from `cc-rpi/templates/rules/` to `.claude/rules/`:
    - Always copy: `rpi-details.md`, `push-accountability.md`
    - If deployment pipeline exists: copy `deployment-safety.md`
    - If using Supabase: copy `supabase.md`
    - If test framework detected: copy `testing.md`
    - Adapt `paths` in frontmatter to match the project's actual file structure.
-9. Create the directory structure (`docs/research/`, `docs/plans/`, `docs/decisions/`).
-10. Set up the README with the standard header.
-11. Add `.claude/settings.local.json` to `.gitignore`.
-12. Walk through the remaining checklist items (pre-commit hooks, CI, git setup) — ask me for decisions where needed.
-13. Unless the user explicitly opts out, always make the project Codex compatible by creating `AGENTS.md`.
-14. If the user says "make this Codex compatible", treat that as an explicit instruction to create or update `AGENTS.md` and verify the Codex compatibility layer is complete.
+11. Create the directory structure (`docs/research/`, `docs/plans/`, `docs/decisions/`).
+12. Set up the README with the standard header.
+13. Add `.claude/settings.local.json` to `.gitignore`.
+14. Walk through the remaining checklist items (pre-commit hooks, CI, git setup) — ask me for decisions where needed.
+15. Unless the user explicitly opts out, always make the project Codex and OpenCode compatible by creating `AGENTS.md`, `opencode.json`, and `.opencode/commands/`.
+16. If the user says "make this Codex compatible" or "make this OpenCode compatible", treat that as an explicit instruction to create or update these compatibility layers and verify they are complete.
 
 ## Phase 4: Save to Memory
 
 After completing all setup:
 
-12. Save the following to auto memory so future sessions start with full awareness:
+1. Save the following to auto memory so future sessions start with full awareness:
     - Project name, type, and stack
     - Key decisions made during setup (git workflow, CI choices, deployment targets)
     - Any project-specific conventions or constraints the user mentioned
     - Which optional features were adopted vs skipped
-    - That the project is Codex compatible via `AGENTS.md`
+    - That the project is Codex/OpenCode compatible via `AGENTS.md`,
+      `opencode.json`, and `.opencode/commands/`
     - The operational rules and error patterns you internalized from Phase 1
 
 This ensures the next session doesn't start from zero — the agent already knows the project context, the rules, and the decisions that shaped the setup.
@@ -81,6 +87,6 @@ for every subsequent task.
 - **Ask before assuming.** Every project is different. Don't guess the stack, conventions, or workflow.
 - **Adapt, don't copy.** The templates are starting points. Tailor everything to this specific project.
 - **Keep CLAUDE.md lean.** Only include instructions that would cause mistakes if missing. If Claude can infer it from code, don't add it.
-- **Create Codex compatibility by default.** Install `AGENTS.md` unless the user explicitly opts out.
+- **Create Codex/OpenCode compatibility by default.** Install `AGENTS.md`, `opencode.json`, and `.opencode/commands/` unless the user explicitly opts out.
 - **Don't read methodology files unless needed.** You have the rules and error patterns memorized from Phase 1. Reference methodology files only when you need depth on a specific topic during setup.
 - **Always save to memory.** Phase 4 is not optional. Every bootstrap must end with a memory save.

--- a/templates/commands/detach.md
+++ b/templates/commands/detach.md
@@ -33,6 +33,9 @@ Check for these files and note which exist:
 
 For each command file that exists, diff it against `<cc-rpi-path>/templates/commands/<name>` to detect customization. Mark as "unmodified" or "customized."
 
+Use `<cc-rpi-path>/templates/commands/INSTALL.md` and `VERIFY.md` as the
+bundle-local reference for what belongs to the command bundle.
+
 For `AGENTS.md`, diff it against `<cc-rpi-path>/templates/AGENTS.md.template` to detect customization. Mark as "unmodified" or "customized."
 
 For `guard-bash.sh`, check if content exists below the `# Project-specific guards below this line` marker. If so, mark as "customized."
@@ -62,6 +65,10 @@ Read `.claude/settings.json` and identify:
 Check for a launchd plist for the cc-rpi update agent:
 
 - `~/Library/LaunchAgents/*cc-rpi*` or `~/Library/LaunchAgents/*blueprint*`
+
+Use `<cc-rpi-path>/templates/scripts/agents/INSTALL.md` and
+`VERIFY.md` as the bundle-local reference for scheduled-agent
+artifacts.
 
 ### Tier 4: User work products
 

--- a/templates/commands/implement.md
+++ b/templates/commands/implement.md
@@ -2,6 +2,14 @@ Implement the plan at: $ARGUMENTS
 
 Model tier: **sonnet** — Sonnet 4.6 (1M context) session. All subagents: `model: "sonnet"`.
 
+Routing mode: `standard`, with an optional `batch` branch when every
+remaining phase is marked `[batch-eligible]`.
+
+Choose `standard` when the path is already planned, the blast radius is
+bounded by the approved phase, and the work should proceed through the
+normal implement-review-verify gate. Upgrade to `batch` only when the
+plan explicitly says the remaining phases are independent.
+
 Process:
 1. Read the plan completely. Check for existing checkmarks.
 2. Spawn Explore agents (model: `"sonnet"`) to gather relevant context.

--- a/templates/commands/plan.md
+++ b/templates/commands/plan.md
@@ -12,12 +12,18 @@ Process:
 7. Propose phase structure, get feedback.
 8. Write detailed plan with separate phase files.
 9. Use pseudocode notation for changes.
-10. Separate automated vs. manual success criteria.
-11. Identify batch-eligible phases: phases that are independent (no file overlap, no
+10. Add a compact **Verifier** section to each phase file with:
+    - target behavior
+    - automated checks
+    - fixtures/data/setup
+    - failure cases or edge conditions
+    - allowed manual exceptions
+11. Separate automated vs. manual success criteria.
+12. Identify batch-eligible phases: phases that are independent (no file overlap, no
     dependency on another phase's output) get marked `[batch-eligible]` in the plan.
     This tells `/implement` that `/batch` can execute them in parallel.
-12. Maximum 3 [NEEDS CLARIFICATION] markers.
-13. Iterate with user until all questions resolved.
+13. Maximum 3 [NEEDS CLARIFICATION] markers.
+14. Iterate with user until all questions resolved.
 
 Save to docs/plans/YYYY-MM-DD-[description].md
 Phase files: docs/plans/YYYY-MM-DD-[description]-phases/phase-N.md

--- a/templates/commands/pre-launch.md
+++ b/templates/commands/pre-launch.md
@@ -6,6 +6,12 @@ handoff.
 
 Model tier: **opus** — Claude Opus 4.6. All specialists: `model: "opus"`.
 
+Routing mode: `deep`
+
+Use this mode when the task demands a harsh, system-wide investigation
+with high blast radius and difficult verification, rather than a normal
+delivery pass.
+
 ## Mindset
 
 > Assume this product will be publicly launched soon and judged by users

--- a/templates/commands/release.md
+++ b/templates/commands/release.md
@@ -32,7 +32,7 @@ Gather release context before making any changes.
    - Check if current branch is main/master
    - Check git log for merge commits from feature/release branches
    - If on main AND no merge-branch pattern: **main-only**
-   - Otherwise: **feature-branch**
+   - Otherwise: **branch-based**
 
 6. **Present findings** to the user:
    - Project type and version source
@@ -134,7 +134,7 @@ and published, then proceed only after approval.
    If the project has a registry publish step, remind the user:
    "Release is published. When ready, run `npm publish` / `cargo publish` / etc."
 
-### Feature-branch flow
+### Branch-based flow
 
 1. Create a release branch and commit:
 

--- a/templates/commands/research.md
+++ b/templates/commands/research.md
@@ -2,6 +2,12 @@ Research the codebase to answer: $ARGUMENTS
 
 Model tier: **opus** — Opus session. All subagents: `model: "opus"`.
 
+Routing mode: `deep`
+
+Choose this mode when ambiguity is high, the blast radius is unclear,
+the work is not yet reversible because you do not understand the system,
+or verification will depend on an accurate model of the current code.
+
 Process:
 1. Read any directly mentioned files FULLY before doing anything else.
 2. Break down the question into research areas.

--- a/templates/commands/status.md
+++ b/templates/commands/status.md
@@ -1,5 +1,11 @@
 Quick project status check. Output a concise orientation and stop.
 
+Routing mode: `quick`
+
+Use this mode when the task is low-ambiguity, low-blast-radius, easily
+reversible, and you only need orientation before deciding whether to
+stop or move into the standard RPI flow.
+
 Run these commands and present the results in a compact summary:
 
 1. `git branch --show-current` — current branch

--- a/templates/commands/triage.md
+++ b/templates/commands/triage.md
@@ -92,6 +92,9 @@ Read-only. Do not modify any files.
    - Cross-reference findings (e.g., coverage report flags X needs tests, code quality report flags X has lint issues -- group them).
    - Identify patterns (multiple agents flagging the same area).
    - Check shared-context.md recommendations against report findings.
+   - If a carried item or repeated finding appears 3+ times, recommend a
+     promotion destination: rule, hook, scripted verifier, or
+     golden-case fixture.
 
 5. **Draft the action plan:**
 
@@ -148,6 +151,7 @@ Reports are NEVER committed (Rule #70). Only code fixes enter version control.
    - **Reports processed**: N
    - **Action items resolved**: M
    - **Summary**: [1-line summary of what was fixed]
+   - **Promotions proposed**: [rule / hook / scripted verifier / golden-case fixture, or "none"]
    **Cross-agent recommendations:**
    - [Agent]: recommendation based on triage findings
    <!-- ENTRY:END -->
@@ -209,6 +213,10 @@ Generate a triage report at `docs/agents/triage-report.md`:
 
 ## Carried Items (if any)
 [Items that persist across multiple triage cycles -- track for escalation]
+
+## Promotion Recommendations (if any)
+| Pattern | Evidence | Destination | Next step |
+|---------|----------|-------------|-----------|
 ```
 
 Present the report summary to the user.
@@ -222,6 +230,9 @@ Present the report summary to the user.
 - **Fix everything (Rule #58).** Categorize findings by severity, but implement 100% of action items. No deferring. No "nothing urgent."
 - **Read every report completely.** No skimming, no summaries-of-summaries. Extract ALL action items from every report.
 - **shared-context.md integration.** Read before analysis, append triage entry after completion.
+- **Promote repeated patterns.** If the same issue keeps returning,
+  recommend the smallest durable promotion: rule, hook, scripted
+  verifier, or golden-case fixture.
 - **CI accountability.** Push is not done until CI is green. Max 3 fix iterations.
 - **Branch verification before every commit.** Run `git branch --show-current` first (Error #33).
 - Run verification commands sequentially, never as parallel Bash calls.

--- a/templates/commands/update.md
+++ b/templates/commands/update.md
@@ -42,6 +42,8 @@ On incremental syncs (lastSyncCommit exists), prioritize reading files that appe
      - If it exists in both locations and the cc-rpi version is different → replace the project version.
      - If it exists in cc-rpi but not in this project → add it.
      - If it exists only in this project → leave it (project-specific command).
+   - If command-bundle behavior is unclear, use `templates/commands/INSTALL.md`
+     and `templates/commands/VERIFY.md` as the local bundle reference.
 
 ## Phase 4: Update Skills
 
@@ -64,50 +66,65 @@ On incremental syncs (lastSyncCommit exists), prioritize reading files that appe
    - Skip stack-irrelevant rules: if not using Supabase, skip `supabase.md`. If no test framework, skip `testing.md`. If no deployment pipeline, skip `deployment-safety.md`.
    - **Never delete** project-added custom rule files.
 
-## Phase 4c: Update AGENTS.md
+## Phase 4c: Update AGENTS.md and OpenCode Layer
 
 10. Read this project's `AGENTS.md` if it exists.
 11. Read cc-rpi's `templates/AGENTS.md.template`.
-12. If `AGENTS.md` does not exist, create it from the template.
-13. If it exists:
+12. Read this project's `opencode.json` if it exists.
+13. Read any files in this project's `.opencode/commands/` if they exist.
+14. Read cc-rpi's `templates/opencode.json.template`.
+15. Read the wrapper command files in `cc-rpi/templates/opencode/commands/`.
+16. If `AGENTS.md` does not exist, create it from the template.
+17. If it exists:
     - Update the compatibility sections so Codex still points at
       `CLAUDE.md`, `.claude/commands/`, `.claude/rules/`, and
-      `.claude/skills/`
+      `.claude/skills/`, and OpenCode still points at the same sources
     - Preserve project-specific sections such as stack notes or custom
-      Codex guidance
+      compatibility guidance
     - If the file has been heavily customized beyond recognition, skip
       and report: "skipped — heavily customized"
+18. If `opencode.json` does not exist, create it from the template.
+19. If it exists, ensure it still loads `CLAUDE.md` and `.claude/rules/*.md` while preserving project-specific OpenCode config.
+20. Compare each file in `cc-rpi/templates/opencode/commands/` against this project's `.opencode/commands/`:
+    - If it exists in both and the cc-rpi version is different → replace the project version.
+    - If it exists in cc-rpi but not in this project → add it.
+    - If it exists only in this project → leave it (project-specific wrapper).
+
+For scheduled-agent sync work, use
+`templates/scripts/agents/INSTALL.md` and
+`templates/scripts/agents/VERIFY.md` as the local reference for what
+the reusable bundle is expected to provide.
 
 ## Phase 5: Update CLAUDE.md
 
-14. Read this project's CLAUDE.md fully.
-15. Read cc-rpi's `templates/CLAUDE.md.template`.
-16. Identify **blueprint-managed sections** by their headers. These sections come from the template and should be kept in sync:
+21. Read this project's CLAUDE.md fully.
+22. Read cc-rpi's `templates/CLAUDE.md.template`.
+23. Identify **blueprint-managed sections** by their headers. These sections come from the template and should be kept in sync:
     - `## RPI Workflow`
     - `## Agent Behavior` (was `## Agent Autonomy` + `## Memory` in older templates)
     - `## Project File Locations`
     - If the project has older sections now moved to `.claude/rules/` (`## Working Patterns`, `## TDD Protocol`, `## Push Accountability`, `<important if>` blocks), remove them and ensure the corresponding rule file exists in `.claude/rules/`.
-17. For each blueprint-managed section:
+24. For each blueprint-managed section:
     - If the project's version differs from the template → update to match.
     - If the project has added project-specific content *within* a blueprint section (e.g., extra rules), preserve it — only update the parts that came from the template.
     - If a section doesn't exist in the project → **add it** from the template. Place it after the last existing blueprint-managed section, preserving the order from the template. New blueprint sections are new knowledge — `/update` is responsible for delivering them.
-18. **Do NOT touch** project-specific sections: One-liner, Stack, Key Commands, Git Workflow, Deployment, Commit Messages, Research Documents, Implementation Plans, or any custom section.
-19. If CLAUDE.md still contains `<important if>` blocks, migrate them to `.claude/rules/` files with `paths` frontmatter and remove the blocks from CLAUDE.md.
-20. The verification sequencing rule ("Run verification sequentially with `;` or `&&`") should be a one-liner in the Git Workflow section, not a separate subsection.
+25. **Do NOT touch** project-specific sections: One-liner, Stack, Key Commands, Git Workflow, Deployment, Commit Messages, Research Documents, Implementation Plans, or any custom section.
+26. If CLAUDE.md still contains `<important if>` blocks, migrate them to `.claude/rules/` files with `paths` frontmatter and remove the blocks from CLAUDE.md.
+27. The verification sequencing rule ("Run verification sequentially with `;` or `&&`") should be a one-liner in the Git Workflow section, not a separate subsection.
 
 ## Phase 6: Update settings.json
 
-21. Read this project's `.claude/settings.json`.
-22. Compare against cc-rpi's `templates/settings.json.template`.
-23. Add any new `permissions.allow` entries from the template that are missing in the project.
-24. Add any new `env` entries from the template that are missing.
-25. **Never remove** project-specific permissions, env vars, hooks, or deny rules.
+28. Read this project's `.claude/settings.json`.
+29. Compare against cc-rpi's `templates/settings.json.template`.
+30. Add any new `permissions.allow` entries from the template that are missing in the project.
+31. Add any new `env` entries from the template that are missing.
+32. **Never remove** project-specific permissions, env vars, hooks, or deny rules.
 
 ## Phase 7: Write Sync Metadata
 
-26. Get the current HEAD commit hash of cc-rpi: `git -C <cc-rpi-path> rev-parse HEAD`
-27. Get the current version tag: `git -C <cc-rpi-path> describe --tags --abbrev=0 2>/dev/null`
-28. Write/update `.claude/cc-rpi-sync.json`:
+33. Get the current HEAD commit hash of cc-rpi: `git -C <cc-rpi-path> rev-parse HEAD`
+34. Get the current version tag: `git -C <cc-rpi-path> describe --tags --abbrev=0 2>/dev/null`
+35. Write/update `.claude/cc-rpi-sync.json`:
     ```json
     {
       "lastSyncCommit": "<commit-hash>",
@@ -121,17 +138,18 @@ On incremental syncs (lastSyncCommit exists), prioritize reading files that appe
 
 ## Phase 8: Report and Commit
 
-29. If any project files were changed (commands, skills, rules, AGENTS.md, CLAUDE.md, settings.json):
+36. If any project files were changed (commands, wrapper commands, skills, rules, AGENTS.md, opencode.json, CLAUDE.md, settings.json):
     - Stage only the changed files (not unrelated changes).
     - Commit with: `chore: sync with cc-rpi blueprint <version-tag>`
     - Always update the sync metadata even if no other files changed.
 
-30. Present a summary:
+37. Present a summary:
     - cc-rpi version synced to (tag + commit hash)
     - Commands updated/added (list them)
     - Skills updated/added (list them)
     - Rules updated/added (list them)
-    - AGENTS.md updated/added (state whether Codex compatibility was installed or synced)
+    - AGENTS.md updated/added (state whether Codex/OpenCode compatibility was installed or synced)
+    - opencode.json updated/added and wrapper commands updated/added
     - CLAUDE.md sections updated/added (list them)
     - settings.json changes (list them)
     - Notable new content: new error patterns, new rules, methodology changes
@@ -141,7 +159,7 @@ On incremental syncs (lastSyncCommit exists), prioritize reading files that appe
 
 - **Never delete project content.** Only add or update blueprint-managed sections.
 - **Preserve project identity.** Stack, deployment, key commands, commit conventions — these are the project's own.
-- **Preserve Codex compatibility.** `AGENTS.md` is part of the blueprint-managed compatibility layer.
+- **Preserve Codex/OpenCode compatibility.** `AGENTS.md`, `opencode.json`, and `.opencode/commands/` are part of the blueprint-managed compatibility layer.
 - **Be idempotent.** Running twice with no cc-rpi changes should produce zero file changes.
 - **Commit atomically.** All sync changes go in one commit with the sync metadata.
 - **If unsure, skip and report.** When a section has been heavily customized beyond the template, leave it alone and note it in the report as "skipped — heavily customized."

--- a/templates/commands/validate.md
+++ b/templates/commands/validate.md
@@ -4,13 +4,18 @@ Model tier: **sonnet** — Sonnet 4.6 (1M context) session.
 
 Process:
 1. Locate the plan (provided path or search recent git history).
-2. Gather evidence: git log, git diff, run test suites.
+2. Read the plan's phase files and extract each phase's **Verifier** section.
+3. Gather evidence: git log, git diff, run test suites, inspect artifacts named in the verifier.
 3. For each phase:
    - Verify marked-complete items are actually done.
-   - Run every automated verification command.
-   - Think about edge cases.
+   - Check the phase against the verifier's target behavior.
+   - Run every automated verification command listed in the verifier.
+   - Confirm fixtures/data/setup assumptions match reality.
+   - Assess listed failure cases or edge conditions.
+   - Confirm any manual exceptions are justified.
 4. Generate a validation report with:
    - Implementation status per phase
+   - Verifier results per phase
    - Automated verification results
    - Code review findings (matches, deviations, issues)
    - Manual testing required (only if automation impossible — explain WHY)

--- a/templates/opencode.json.template
+++ b/templates/opencode.json.template
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": [
+    "CLAUDE.md",
+    ".claude/rules/*.md"
+  ]
+}

--- a/templates/opencode/commands/adopt.md
+++ b/templates/opencode/commands/adopt.md
@@ -1,0 +1,9 @@
+---
+description: Adopt cc-rpi into an existing project using the canonical workflow
+---
+
+Follow the workflow in @templates/commands/adopt.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/templates/opencode/commands/bootstrap.md
+++ b/templates/opencode/commands/bootstrap.md
@@ -1,0 +1,9 @@
+---
+description: Bootstrap a project from cc-rpi using the canonical workflow
+---
+
+Follow the workflow in @templates/commands/bootstrap.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/templates/opencode/commands/describe-pr.md
+++ b/templates/opencode/commands/describe-pr.md
@@ -1,0 +1,9 @@
+---
+description: Generate a PR description using the canonical workflow
+---
+
+Follow the workflow in @templates/commands/describe-pr.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/templates/opencode/commands/detach.md
+++ b/templates/opencode/commands/detach.md
@@ -1,0 +1,9 @@
+---
+description: Detach a project from cc-rpi using the canonical workflow
+---
+
+Follow the workflow in @templates/commands/detach.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/templates/opencode/commands/fix-ci.md
+++ b/templates/opencode/commands/fix-ci.md
@@ -1,0 +1,9 @@
+---
+description: Diagnose and fix CI using the canonical workflow
+---
+
+Follow the workflow in @templates/commands/fix-ci.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/templates/opencode/commands/implement.md
+++ b/templates/opencode/commands/implement.md
@@ -1,0 +1,11 @@
+---
+description: Execute an implementation phase using the canonical workflow
+---
+
+Follow the workflow in @templates/commands/implement.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+This is the `standard` routing mode entry point, with `batch` available
+only when the plan marks the remaining phases `[batch-eligible]`.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/templates/opencode/commands/plan.md
+++ b/templates/opencode/commands/plan.md
@@ -1,0 +1,10 @@
+---
+description: Create an implementation plan using the canonical workflow
+---
+
+Follow the workflow in @templates/commands/plan.md exactly.
+That canonical workflow includes the per-phase **Verifier** contract.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/templates/opencode/commands/pre-launch.md
+++ b/templates/opencode/commands/pre-launch.md
@@ -1,0 +1,10 @@
+---
+description: Run the pre-launch audit using the canonical workflow
+---
+
+Follow the workflow in @templates/commands/pre-launch.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+This is the `deep` routing mode entry point.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/templates/opencode/commands/release.md
+++ b/templates/opencode/commands/release.md
@@ -1,0 +1,9 @@
+---
+description: Prepare a release using the canonical workflow
+---
+
+Follow the workflow in @templates/commands/release.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/templates/opencode/commands/remediate.md
+++ b/templates/opencode/commands/remediate.md
@@ -1,0 +1,9 @@
+---
+description: Remediate findings using the canonical workflow
+---
+
+Follow the workflow in @templates/commands/remediate.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/templates/opencode/commands/research.md
+++ b/templates/opencode/commands/research.md
@@ -1,0 +1,10 @@
+---
+description: Research the codebase using the canonical workflow
+---
+
+Follow the workflow in @templates/commands/research.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+This is the `deep` routing mode entry point.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/templates/opencode/commands/status.md
+++ b/templates/opencode/commands/status.md
@@ -1,0 +1,10 @@
+---
+description: Show project status using the canonical workflow
+---
+
+Follow the workflow in @templates/commands/status.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+This is the `quick` routing mode entry point.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/templates/opencode/commands/triage.md
+++ b/templates/opencode/commands/triage.md
@@ -1,0 +1,9 @@
+---
+description: Process agent reports using the canonical workflow
+---
+
+Follow the workflow in @templates/commands/triage.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/templates/opencode/commands/update-docs.md
+++ b/templates/opencode/commands/update-docs.md
@@ -1,0 +1,9 @@
+---
+description: Update documentation using the canonical workflow
+---
+
+Follow the workflow in @templates/commands/update-docs.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/templates/opencode/commands/update.md
+++ b/templates/opencode/commands/update.md
@@ -1,0 +1,9 @@
+---
+description: Sync a project with cc-rpi using the canonical workflow
+---
+
+Follow the workflow in @templates/commands/update.md exactly.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/templates/opencode/commands/validate.md
+++ b/templates/opencode/commands/validate.md
@@ -1,0 +1,10 @@
+---
+description: Validate implementation using the canonical workflow
+---
+
+Follow the workflow in @templates/commands/validate.md exactly.
+That canonical workflow includes reading each phase's **Verifier** section.
+
+Treat that file as the canonical command spec.
+Preserve the existing cc-rpi workflow and command name.
+Use these command arguments as additional context: `$ARGUMENTS`

--- a/templates/rules/rpi-details.md
+++ b/templates/rules/rpi-details.md
@@ -44,3 +44,14 @@ description: RPI workflow details -- phase rules, pre-release sequence, implemen
 Prefer automated verification.
 Manual only for: sudo, hardware, new installs, visual-only.
 Don't use Claude for linting/formatting -- use tools and hooks.
+
+## Verification Contract
+
+- Each plan phase should include a compact **Verifier** section.
+- Verifier contents:
+  - target behavior
+  - automated checks
+  - fixtures/data/setup
+  - failure cases or edge conditions
+  - allowed manual exceptions
+- `/validate` should read the verifier before running checks.

--- a/templates/rules/testing.md
+++ b/templates/rules/testing.md
@@ -29,3 +29,14 @@ Refactors need existing coverage. No "tests later."
 
 Run checks sequentially, never as parallel Bash calls
 (hook enforced). Chain: `typecheck ; lint ; test`
+
+## Phase Verifier
+
+Each plan phase should include a compact verifier section so the
+validator knows:
+
+1. What target behavior to confirm
+2. Which automated checks to run
+3. Which fixtures or setup assumptions matter
+4. Which edge cases to inspect
+5. Which manual exceptions are allowed, with WHY

--- a/templates/scripts/agents/INSTALL.md
+++ b/templates/scripts/agents/INSTALL.md
@@ -1,0 +1,40 @@
+# Scheduled Agents Bundle — INSTALL
+
+This bundle contains the reusable pieces for project-local scheduled
+agents:
+
+- `install-agents.sh` — installs launchd jobs from `# SCHEDULE:` comments
+- `lib/agent-utils.sh` — shared runtime helpers for agent scripts
+- example scripts such as `cc-rpi-update-agent.sh` and
+  `morning-triage.sh`
+
+## Prerequisites
+
+- macOS with `launchd` if you want to use `install-agents.sh`
+- Claude CLI installed and authenticated with `claude setup-token`
+- Project directories:
+  - `scripts/agents/`
+  - `scripts/agents/lib/`
+  - `docs/agents/`
+  - `logs/`
+
+## Install Steps
+
+1. Copy `lib/agent-utils.sh` into `scripts/agents/lib/`.
+2. Copy `install-agents.sh` into `scripts/agents/`.
+3. Copy or author one or more agent scripts into `scripts/agents/`.
+4. Add a `# SCHEDULE:` comment to each script you want auto-installed.
+5. Make the scripts executable.
+6. Run:
+
+```bash
+bash scripts/agents/install-agents.sh
+```
+
+## Notes
+
+- The installer only picks up scripts with a `# SCHEDULE:` comment.
+- The installer skips itself and the multi-project `morning-triage.sh`
+  orchestrator.
+- For Linux or custom scheduling, use this bundle as reference and adapt
+  the scripts to cron or your own scheduler.

--- a/templates/scripts/agents/VERIFY.md
+++ b/templates/scripts/agents/VERIFY.md
@@ -1,0 +1,46 @@
+# Scheduled Agents Bundle — VERIFY
+
+Use this after installing the scheduled-agents bundle into a project.
+
+## Verify the Bundle Exists
+
+- `scripts/agents/install-agents.sh` exists
+- `scripts/agents/lib/agent-utils.sh` exists
+- at least one agent script exists in `scripts/agents/`
+
+## Verify Schedules Are Discoverable
+
+Run:
+
+```bash
+bash scripts/agents/install-agents.sh --list
+```
+
+Expected result:
+- each scheduled agent appears once
+- scripts without `# SCHEDULE:` comments are skipped
+
+## Verify Installation
+
+Run:
+
+```bash
+bash scripts/agents/install-agents.sh --status
+```
+
+Expected result:
+- launchd labels appear for installed agents
+- no immediate bootstrap/load failure is reported
+
+## Verify Runtime Output
+
+1. Start one agent manually with `launchctl start <label>`.
+2. Confirm it produces:
+   - a report in `docs/agents/`
+   - a log file in `logs/` or `~/Library/Logs/<project>/`
+
+## Manual Exceptions
+
+- Linux/cron projects will verify scheduling differently.
+- Agents that require project dependencies or external services may need
+  a project-specific smoke run after installation.

--- a/templates/scripts/agents/install-agents.sh
+++ b/templates/scripts/agents/install-agents.sh
@@ -18,6 +18,10 @@
 #   bash scripts/agents/install-agents.sh --status     # Show agent status
 #   bash scripts/agents/install-agents.sh --list       # List discoverable agents
 #
+# Bundle-local docs:
+#   - INSTALL.md  # prerequisites and install steps
+#   - VERIFY.md   # post-install verification checks
+#
 # Prerequisites:
 #   - macOS with launchd
 #   - Claude CLI installed (claude setup-token for non-interactive auth)

--- a/templates/setup-checklist.md
+++ b/templates/setup-checklist.md
@@ -19,13 +19,22 @@ Use this when setting up a new project to follow cc-rpi best practices.
   - Manually craft every line — don't auto-generate with `/init`
   - Keep it lean: only universally applicable instructions
 - [ ] Create `AGENTS.md` at project root (adapt from `AGENTS.md.template`)
-  - This is the Codex compatibility layer for cc-rpi projects
-  - Point Codex at `CLAUDE.md`, `.claude/commands/`, `.claude/rules/`,
-    and `.claude/skills/` as the source of truth
+  - This is the Codex/OpenCode compatibility layer for cc-rpi projects
+  - Point Codex and OpenCode at `CLAUDE.md`, `.claude/commands/`,
+    `.claude/rules/`, and `.claude/skills/` as the source of truth
   - Keep Codex-only helpers that would collide with Claude-native
     commands out of `.claude/skills/`
   - Keep it focused on workflow translation, not duplicate project docs
 - [ ] Create `.claude/commands/` and copy slash commands from `templates/commands/`
+- [ ] Create `.opencode/commands/` and copy wrapper commands from
+  `templates/opencode/commands/`
+  - Keep these wrappers thin; they should delegate back to
+    `.claude/commands/*.md`
+  - Do not duplicate the workflow text into OpenCode-only command files
+- [ ] Create `opencode.json` at project root
+  - Adapt from `templates/opencode.json.template`
+  - Load `CLAUDE.md` and `.claude/rules/*.md` through `instructions`
+  - Keep command discovery in `.opencode/commands/`
 - [ ] Create `.claude/skills/` for domain-specific knowledge (loaded on demand):
   - Each skill is a **folder** with a `SKILL.md` entry point, plus optional `references/`, `scripts/`, `examples/`, `assets/` subdirectories
   - Start with library reference and code quality skills (highest immediate value)
@@ -65,10 +74,14 @@ Two file pairs follow the same split pattern:
 
 **`settings.local.json`** — Personal permission overrides (e.g., broader `Bash(*)` for your machine), local env vars. Gitignored.
 
-**`AGENTS.md`** — Codex compatibility bridge. Teaches Codex how to
-interpret the existing cc-rpi layout (`CLAUDE.md`, `.claude/commands/`,
-`.claude/rules/`, `.claude/skills/`) without changing the methodology.
-Committed.
+**`AGENTS.md`** — Codex/OpenCode compatibility bridge. Teaches those
+agents how to interpret the existing cc-rpi layout (`CLAUDE.md`,
+`.claude/commands/`, `.claude/rules/`, `.claude/skills/`) without
+changing the methodology. Committed.
+
+**`opencode.json`** — OpenCode instruction loader. Pulls `CLAUDE.md`
+and `.claude/rules/*.md` into OpenCode without duplicating the content
+in `AGENTS.md`. Committed.
 
 ## CLAUDE.md Configuration
 
@@ -97,10 +110,12 @@ Committed.
 - [ ] Add project-specific context (key routes, data types, code ownership)
 - [ ] Keep `AGENTS.md` aligned with the project's workflow conventions:
   - Slash-style commands dispatch to `.claude/commands/*.md`
+  - OpenCode slash-style commands dispatch via `.opencode/commands/*.md`
+    wrappers back to `.claude/commands/*.md`
   - `.claude/rules/` remains the rule source of truth
   - `.claude/skills/` remains the skill source of truth
   - Claude-native commands (`/simplify`, `/batch`, `/worktree`) are
-    translated to Codex-equivalent behavior
+    translated to Codex/OpenCode-equivalent behavior
   - Codex-only helpers that would shadow native Claude commands stay in
     `~/.codex/skills/`, not `.claude/skills/`
 
@@ -117,9 +132,18 @@ Copy and adapt from `templates/commands/`:
 
 Adjust file paths in each command to match your project's docs directory.
 
+- [ ] Read the local command-bundle manifests before large command sync or
+  setup changes:
+  - `templates/commands/INSTALL.md`
+  - `templates/commands/VERIFY.md`
+
 For Codex compatibility, `AGENTS.md` should instruct Codex to treat each
 file in `.claude/commands/` as the workflow spec when the user invokes
 the matching slash-style command.
+
+For OpenCode compatibility, each file in `.opencode/commands/` should be
+a thin wrapper that points back to the matching file in
+`.claude/commands/`.
 
 **Slash commands vs skills:** Commands (`.claude/commands/`) are user-invoked workflows. Skills (`.claude/skills/`) are knowledge + workflows that Claude can also auto-detect. Use commands for RPI phases; use skills for domain conventions and reusable task patterns.
 
@@ -188,19 +212,21 @@ the matching slash-style command.
   - (Optional) Security audit, E2E tests
 - [ ] Mark critical CI jobs as required for PR merges
 - [ ] Enable branch protection on the production branch (require CI + review)
-- [ ] Verify CI runs successfully on the development branch
+- [ ] Verify CI runs successfully on the branch used for active development
 
 ## Git Setup
 
-- [ ] Initialize repo with `main` as production branch
-- [ ] Create `develop` as default working branch
+- [ ] Choose a branch strategy and document it in `CLAUDE.md`:
+  - Branch-based release flow: `main` is production and `develop` (or another integration branch) is the default working branch
+  - Main-only flow: `main` is both the default and production branch, usually with tagged releases
+- [ ] Initialize the repo branches to match that strategy
 - [ ] Set up branch protection rules on GitHub
 - [ ] Configure pre-commit hooks (typecheck, lint, test) — see Pre-Commit Hooks above
 
 ## Push Accountability
 
 - [ ] Add push accountability instructions to CLAUDE.md or CLAUDE.local.md:
-  - After every push to develop, spawn a background CI monitor
+  - After every push to the branch used for active development, spawn a background CI monitor
   - Background agent polls, investigates failures, fixes, and re-pushes
   - Main terminal stays unblocked
 - [ ] Test the workflow: push a deliberate failure, verify the background agent catches it
@@ -237,6 +263,9 @@ The shell script reads update instructions from cc-rpi at runtime, so when cc-rp
 ## Scheduled Agents (Optional)
 
 - [ ] Create `scripts/agents/` and `scripts/agents/lib/` directories
+- [ ] Read the local scheduled-agent manifests before installing:
+  - `templates/scripts/agents/INSTALL.md`
+  - `templates/scripts/agents/VERIFY.md`
 - [ ] Copy `lib/agent-utils.sh` from `cc-rpi/templates/scripts/agents/lib/agent-utils.sh` to `scripts/agents/lib/`
 - [ ] Copy `install-agents.sh` from `cc-rpi/templates/scripts/agents/install-agents.sh` to `scripts/agents/`
 - [ ] Create `docs/agents/` directory for agent reports and shared context
@@ -283,6 +312,8 @@ The shell script reads update instructions from cc-rpi at runtime, so when cc-rp
 - [ ] Keep the methodology stable across agents:
   - Claude Code uses `.claude/commands/`, `.claude/rules/`,
     `.claude/skills/`
+  - OpenCode uses `AGENTS.md`, `opencode.json`, `.opencode/commands/`,
+    and also understands `.claude/skills/`
   - Codex uses `AGENTS.md` to interpret those same artifacts
   - The workflow stays the same; only the harness translation changes
 
@@ -296,7 +327,8 @@ The standard setup applies as-is. Typical stack badges: framework (Next.js, Remi
 
 ### Library / npm Package
 
-- **Git workflow:** May use `main` only (no `develop`) if releases are tagged from `main`
+- **Git workflow:** Often uses `main` only (no `develop`) when releases
+  are tagged directly from `main`
 - **CI additions:** Add `npm pack` or `pnpm pack` verification, publish dry-run
 - **Testing:** Prioritize unit tests and type-level tests. Add consumer integration tests (test the package from a downstream project's perspective)
 - **CLAUDE.md:** Document the public API surface. Add "do not change exports without a major version bump" rule
@@ -312,7 +344,9 @@ The standard setup applies as-is. Typical stack badges: framework (Next.js, Remi
 
 ### Monorepo
 
-- **Git workflow:** Same `develop`/`main` pattern, but CI runs per-package with change detection
+- **Git workflow:** Often keeps the same integration-branch /
+  production-branch split, but CI runs per-package with change
+  detection
 - **CI additions:** Use `turbo`/`nx` affected detection. Only run checks for changed packages
 - **CLAUDE.md:** Document the workspace structure, how packages depend on each other, which package owns which feature
 - **Pre-commit:** Run typecheck across ALL workspace packages (not just changed ones — cross-package type errors are common)
@@ -329,7 +363,8 @@ The standard setup applies as-is. Typical stack badges: framework (Next.js, Remi
 
 ### Static Site / Documentation
 
-- **Git workflow:** May deploy directly from `main` (no `develop` needed for simple sites)
+- **Git workflow:** May deploy directly from `main` when the project
+  does not need a separate integration branch
 - **CI:** Build verification + link checking + image optimization check
 - **Testing:** Minimal — focus on build success and broken link detection
 - **CLAUDE.md:** Keep lean. Document build command, content directory structure, frontmatter conventions

--- a/templates/skills/deployment-safety/SKILL.md
+++ b/templates/skills/deployment-safety/SKILL.md
@@ -13,11 +13,11 @@ Wrong -- merge Dependabot PR thinking it's cleanup:
 gh pr merge 42 --merge  # Dependabot targets main = production deploy
 ```
 
-Right -- cherry-pick to develop, close the PR:
+Right -- cherry-pick to the integration branch, close the PR:
 
 ```bash
-git checkout develop && git cherry-pick <commit>
-gh pr close 42  # release via normal develop -> main process
+git checkout <integration-branch> && git cherry-pick <commit>
+gh pr close 42  # release via normal integration -> main process
 ```
 
 ## Dependency Batching
@@ -32,7 +32,7 @@ gh pr merge 1 && gh pr merge 2 && gh pr merge 3
 Right -- batch into a single branch:
 
 ```bash
-git checkout -b chore/dependency-updates develop
+git checkout -b chore/dependency-updates <integration-branch>
 # Apply all updates, run CI once, merge one PR
 ```
 
@@ -80,7 +80,7 @@ Right -- roll back first, investigate second:
 ```bash
 vercel rollback  # Step 1: restore service immediately
 # Step 2: investigate on non-production (logs, preview URL)
-# Step 3: fix on develop, verify on preview, then PR to main
+# Step 3: fix on the integration branch, verify on preview, then PR to main
 ```
 
 ## Justify Every Action


### PR DESCRIPTION
## What does this PR do?
Align cc-rpi branch-topology and worktree guidance with upstream v1.17.1, then add explicit workflow routing, per-phase verifier contracts, promotion paths from logs into durable assets, thin bundle-local INSTALL.md / VERIFY.md manifests, and full OpenCode/Codex compatibility wiring.

## Concretely, PR does four things:

1. Reconciles workflow docs so repo no longer mixes incompatible branch models:
Repo-local cc-rpi now treats main as long-lived canonical branch, while methodology and templates describe explicit integration-branch / production-branch topology and require implementation in worktrees or temporary branches.

2. Strengthens core RPI execution model.
Adds routing modes (quick, standard, deep, batch), adds compact Verifier sections to plan/validate flow, and extends repeated-pattern promotion beyond prose rules into hooks, scripted verifiers, and golden-case fixtures.

3. Adds thin reusable bundle manifests.
Introduces local INSTALL.md / VERIFY.md files for command bundle and scheduled-agent bundle, then points setup and lifecycle docs at those local references instead of duplicating detail inline.

4. Adds OpenCode and Codex bridge layer without forking workflow logic.
Adds opencode.json, repo-local and template .opencode/commands/* wrappers, expands AGENTS.md guidance, and keeps .claude/commands/*.md / templates/commands/*.md as canonical workflow sources.

## Type of change
- [ ] New error pattern
- [X] Methodology improvement
- [X] Template update
- [X] Documentation fix
- [X] Other (describe)
Cross-harness compatibility layer for OpenCode and Codex, plus upstream merge reconciliation

## Checklist
- [x] Entries are generic (no project-specific references)
- [x] Follows existing format and structure
- [x] Updated patterns/quick-reference.md if adding a new pattern
- [x] Tested the pattern/approach across at least two sessions (if applicable)
If want more explicit PR body, use this expanded version under summary:

### Key changes
- Normalize branch-topology language across CLAUDE.md, methodology, templates, setup checklist, and deployment-safety guidance.
- Keep upstream v1.17.1 consistency fixes while preserving local cc-rpi improvements.
- Add verifier contract fields to planning and validation docs: target behavior, automated checks, fixtures/setup, failure cases, manual exceptions.
- Add routing vocabulary to live commands, templates, guide docs, and AGENTS guidance.
- Extend log-promotion model to rules, hooks, scripted verifiers, and golden-case fixtures.
- Add bundle-local INSTALL.md / VERIFY.md manifests for commands and scheduled agents.
- Add OpenCode wrapper command surface and exported OpenCode templates.
- Keep OpenCode wrappers thin so same slash commands still dispatch to canonical cc-rpi workflows.

### Validation
- Reviewed merged state for wrapper parity, branch-topology consistency, verifier/routing coverage, and broken references.
- Confirmed .opencode/commands/* and templates/opencode/commands/* fully map to existing canonical targets.
- Confirmed opencode.json matches exported template.
- Confirmed merge clean, worktree clean, and fork now contains all local commits.
