### PR TITLE
release: v1.21.0 -- plugin packaging, /brainstorm, systematic-debugging

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "cc-rpi",
+  "description": "The cc-rpi blueprint as an installable plugin: Research-Plan-Implement workflow commands, domain skills, and an agent-error knowledge base.",
+  "owner": {
+    "name": "Juan Gonzalez",
+    "url": "https://github.com/juan294"
+  },
+  "plugins": [
+    {
+      "name": "cc-rpi",
+      "source": "./",
+      "description": "Research-Plan-Implement methodology, domain skills, and a 63-pattern agent-error knowledge base for Claude Code.",
+      "version": "1.20.0"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "cc-rpi",
       "source": "./",
       "description": "Research-Plan-Implement methodology, domain skills, and a 63-pattern agent-error knowledge base for Claude Code.",
-      "version": "1.20.0"
+      "version": "1.21.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "cc-rpi",
+  "displayName": "cc-rpi -- RPI Methodology",
+  "description": "Research-Plan-Implement methodology for Claude Code: phased workflow commands, domain skills, and a 63-pattern agent-error knowledge base.",
+  "version": "1.20.0",
+  "author": {
+    "name": "Juan Gonzalez"
+  },
+  "homepage": "https://github.com/juan294/cc-rpi",
+  "repository": "https://github.com/juan294/cc-rpi",
+  "license": "MIT",
+  "keywords": [
+    "rpi",
+    "methodology",
+    "research-plan-implement",
+    "workflow",
+    "agent-errors"
+  ],
+  "skills": "./templates/skills/",
+  "commands": "./templates/commands/"
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "cc-rpi",
   "displayName": "cc-rpi -- RPI Methodology",
   "description": "Research-Plan-Implement methodology for Claude Code: phased workflow commands, domain skills, and a 63-pattern agent-error knowledge base.",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "author": {
     "name": "Juan Gonzalez"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **`/brainstorm` command (optional RPI pre-step).** Socratic, one-question-at-a-time
+  intake for vague or greenfield work where the request is a goal, not a spec and
+  there is no existing code to `/research`. Produces a design brief in
+  `docs/research/YYYY-MM-DD-*-brief.md` that `/plan` consumes. Documented as an
+  optional front end, not a fifth phase. `templates/commands/brainstorm.md`.
+- **`systematic-debugging` skill.** Auto-consulted (`user-invocable: false`)
+  procedure for novel bugs: reproduce -> isolate -> hypothesize -> test ->
+  fix-root-cause -> verify, plus stop-conditions. Routes known tool/git/CI
+  failures to the error-patterns skill. Brings `templates/skills/` to 10.
+- **Installable as a Claude Code plugin.** Added `.claude-plugin/plugin.json`
+  (manifest pointing `skills`/`commands` at the existing `templates/` dirs --
+  no file moves) and `.claude-plugin/marketplace.json` so the repo is its own
+  self-hosted marketplace. Install with
+  `/plugin marketplace add juan294/cc-rpi` then `/plugin install cc-rpi@cc-rpi`.
+  Commands/skills namespace as `/cc-rpi:research`, `/cc-rpi:brainstorm`, etc.
+  Passes `claude plugin validate`. The blueprint/copy model is unchanged and
+  continues to work alongside the plugin.
+
 ### Fixed
 
 - **Nightly `cc-rpi-update` agent could not edit `.claude/` files.** The scheduled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.21.0] - 2026-06-19
+
 ### Added
 
 - **`/brainstorm` command (optional RPI pre-step).** Socratic, one-question-at-a-time
@@ -25,6 +27,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   Commands/skills namespace as `/cc-rpi:research`, `/cc-rpi:brainstorm`, etc.
   Passes `claude plugin validate`. The blueprint/copy model is unchanged and
   continues to work alongside the plugin.
+
+### Changed
+
+- **Documentation consistency sweep for the additions above.** `/bootstrap` and
+  `setup-checklist.md` now install `systematic-debugging/` and list `/brainstorm`,
+  so new projects pick up both; GUIDE skill count corrected 9 -> 10 (two places)
+  with `systematic-debugging` enumerated; `four-phases.md` topology diagram shows
+  `/brainstorm` as an optional pre-step; bootstrap example command count fixed.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ Go directly to these paths -- never search the codebase for them.
 | Error catalog | `patterns/agent-errors.md` | 63 errors, source of truth |
 | Operational rules | `patterns/quick-reference.md` | 76 rules with scope/stack tags |
 | Deployment safety | `patterns/deployment-safety.md` | Resource efficiency rules |
-| Skill templates | `templates/skills/` | 9 domain skills |
+| Skill templates | `templates/skills/` | 10 domain skills |
 | Codex-only skills | `.codex/skills/` | Personal Codex helpers such as `codex-simplify` |
 | Rule templates | `templates/rules/` | 5 conditional/universal rules |
 | Active rules | `.claude/rules/` | cc-rpi's own rules |

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -313,7 +313,7 @@ This sounds restrictive, but it's the single most impactful rule for research qu
 
 The blueprint includes 76 operational rules learned from real sessions. These aren't theoretical — they're patterns that caused actual failures and wasted time. Rather than loading all rules into every session, the blueprint uses **progressive disclosure** across three layers: a slim CLAUDE.md (~70 lines) for universal instructions, `.claude/rules/` for conditional rules that load only when working with matching files, and `.claude/skills/` for detailed domain knowledge that loads on demand. This keeps the agent's context window clean and focused.
 
-The 9 blueprint-provided skills cover: git workflow, CI verification, deployment safety, multi-agent coordination, GitHub CLI, Python, macOS, Supabase, and error patterns. The 5 rule templates cover: RPI details, push accountability, deployment safety, Supabase, and testing.
+The 10 blueprint-provided skills cover: git workflow, CI verification, deployment safety, multi-agent coordination, GitHub CLI, Python, macOS, Supabase, error patterns, and systematic debugging. The 5 rule templates cover: RPI details, push accountability, deployment safety, Supabase, and testing.
 
 ### Agent Teams
 
@@ -457,7 +457,7 @@ The blueprint repository contains detailed documentation on every topic mentione
 | Model economics | `methodology/cost-monitoring.md` | Cost pools, model-tier binding, access tiers, cost-per-outcome |
 | Error patterns | `patterns/agent-errors.md` | 63 documented errors with symptoms and solutions |
 | Operational rules | `patterns/quick-reference.md` | 76 rules with scope/stack tags, organized by domain |
-| Domain skills | `templates/skills/` | 9 blueprint-provided skills for progressive disclosure |
+| Domain skills | `templates/skills/` | 10 blueprint-provided skills for progressive disclosure |
 | Rule templates | `templates/rules/` | 5 conditional/modular rules for `.claude/rules/` |
 | Deployment safety | `patterns/deployment-safety.md` | Resource efficiency and production deployment rules |
 | Worked examples | `examples/README.md` | Sample research docs, plans, logs, pseudocode |

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -89,6 +89,30 @@ Now you have four commands available everywhere:
 | `/update` | **Keep in sync.** Pulls latest cc-rpi changes and updates your project's commands, rules, and settings. Run manually or schedule nightly. |
 | `/detach` | **Part ways.** Cleanly removes all cc-rpi artifacts while preserving your project-specific config and work products. |
 
+#### Alternative: install as a plugin
+
+cc-rpi also ships as a Claude Code plugin. Instead of copying command files,
+add the repo as a marketplace and install — the RPI commands and skills then
+load namespaced (`/cc-rpi:research`, `/cc-rpi:brainstorm`, `/cc-rpi:plan`, …)
+in every project, with no per-file path editing:
+
+```bash
+/plugin marketplace add juan294/cc-rpi
+/plugin install cc-rpi@cc-rpi
+```
+
+For local development of the plugin itself, load it in place and validate:
+
+```bash
+claude --plugin-dir /path/to/cc-rpi      # load without installing
+claude plugin validate /path/to/cc-rpi   # run the marketplace review checks
+```
+
+The plugin and the blueprint/copy model coexist — use whichever fits. The
+plugin gives you the commands everywhere; the blueprint still drives
+project-level setup (`CLAUDE.md`, `AGENTS.md`, rules, CI) via `/bootstrap`
+and `/adopt`.
+
 ### Step 2: Set Up Your Project
 
 **Starting a new project?** Open Claude Code in the project directory and type:
@@ -159,6 +183,7 @@ install when you want the same cleanup pass in Codex.
 
 | Command | What It Does | When to Use |
 |---------|-------------|-------------|
+| `/brainstorm [idea]` | Optional front end to RPI. Refines a vague or greenfield idea through one-question-at-a-time Socratic intake into a design brief at `docs/research/`. Feeds `/plan`. | When the request is a goal, not a spec — and there's no existing code to `/research`. |
 | `/describe-pr` | Generates a PR description from the current branch's diff and commit history. | Before opening or updating a PR. |
 | `/pre-launch` | Spawns 8 parallel specialist agents (Principal Architect, Staff FE, Staff BE, Performance Engineer, DevOps/SRE Lead, Security Reviewer, QA/Reliability Lead, Product Designer/UX Lead) for a deep launch-readiness audit. Produces a 16-section report with 5-tier severity findings, finding IDs, and Before/After/Later time horizons. | Before any production release. Run `/remediate` after to fix findings in 3 waves. |
 | `/remediate` | Parses the 16-section pre-launch report, groups findings by wave (Before / After / Later launch), creates GitHub issues for every finding (Rule #58), spawns parallel TDD agents per wave in worktrees, merges sequentially, verifies CI, runs `/simplify` twice per wave. Wave 3 strategic items are filed as issues but not auto-fixed. | After `/pre-launch` when findings exist. Automates the full fix cycle in 3 waves. |
@@ -174,7 +199,7 @@ Each command runs on a model tier — frontier where reasoning matters, the chea
 
 | Tier | Commands | Why |
 |------|----------|-----|
-| **opus** (frontier) | `/research`, `/plan`, `/pre-launch` | Deep reasoning — a bad output amplifies downstream. |
+| **opus** (frontier) | `/brainstorm`, `/research`, `/plan`, `/pre-launch` | Deep reasoning — a bad output amplifies downstream. |
 | **sonnet** (mid) | `/implement`, `/validate`, `/remediate`, `/fix-ci`, `/triage`, `/bootstrap`, `/adopt`, `/detach`, `/release`, `/update-docs`, `/update` | Executes against a reviewed plan. |
 | **haiku** (floor) | `/status`, `/describe-pr` | Mechanical read-and-summarize. |
 
@@ -216,7 +241,7 @@ You type `/research how does authentication work in this app?` and the agent:
 
 The critical rule here is **documentarian, not critic**. The research describes what exists — it doesn't suggest improvements or identify problems. This keeps the research factual and prevents the agent from jumping to solutions before understanding the problem.
 
-Note: /research is for projects that already have code. If you just bootstrapped a new project and have no code yet, skip /research and start with /plan — there's nothing to research. Once you have code from your first implementation, /research becomes your starting point for every subsequent task.
+Note: /research is for projects that already have code. If you just bootstrapped a new project and have no code yet, skip /research and start with /plan — there's nothing to research. When the idea itself is still vague (a goal, not a spec), run /brainstorm first to turn it into a design brief, then /plan. Once you have code from your first implementation, /research becomes your starting point for every subsequent task.
 
 **Your job:** Read the research document. If it's wrong or incomplete, throw it out and run `/research` again with more specific steering. Multiple passes are normal. Don't approve bad research — it poisons everything downstream.
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Ready-to-use starting points for new projects:
 - **Rule templates** — `.claude/rules/` files with conditional loading (deployment, Supabase, testing) and universal rules (RPI details, push accountability)
 - **settings.json template** — `.claude/settings.json` with Agent Teams, hooks, and permissions
 - **Setup checklist** — Step-by-step guide including rules, skills, hooks, CI, and scheduled agents
-- **Slash commands** — `/bootstrap`, `/adopt`, `/update`, `/research`, `/plan`, `/implement`, `/validate`, `/describe-pr`, `/pre-launch`, `/remediate`, `/triage`, `/status`, `/fix-ci` — plus Anthropic-native `/simplify` and `/batch`
+- **Slash commands** — `/bootstrap`, `/adopt`, `/update`, `/brainstorm`, `/research`, `/plan`, `/implement`, `/validate`, `/describe-pr`, `/pre-launch`, `/remediate`, `/triage`, `/status`, `/fix-ci` — plus Anthropic-native `/simplify` and `/batch`
 - **Scheduled agent scripts** — Nightly blueprint sync and multi-project morning triage with launchd/cron templates
 
 ## Adding New Patterns

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cc-rpi — Claude Code Reference & Project Intelligence
 
 [![CI](https://github.com/juan294/cc-rpi/actions/workflows/validate.yml/badge.svg)](https://github.com/juan294/cc-rpi/actions/workflows/validate.yml)
-[![Version: v1.20.0](https://img.shields.io/badge/Version-v1.20.0-orange.svg)](https://github.com/juan294/cc-rpi/releases/tag/v1.20.0)
+[![Version: v1.21.0](https://img.shields.io/badge/Version-v1.21.0-orange.svg)](https://github.com/juan294/cc-rpi/releases/tag/v1.21.0)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Status: Active](https://img.shields.io/badge/Status-Active-brightgreen.svg)]()
 [![Claude Code](https://img.shields.io/badge/Built%20for-Claude%20Code-blueviolet.svg)](https://docs.anthropic.com/en/docs/claude-code)

--- a/examples/workflows/bootstrap-new-project.md
+++ b/examples/workflows/bootstrap-new-project.md
@@ -51,7 +51,7 @@ Claude: Setting up your project. Here's what I'm creating:
 
 - CLAUDE.md — project configuration with all operational rules
 - .claude/settings.json — permissions, Agent Teams, hooks
-- .claude/commands/ — all 6 slash commands (research, plan, implement, validate, describe-pr, pre-launch)
+- .claude/commands/ — all 7 slash commands (brainstorm, research, plan, implement, validate, describe-pr, pre-launch)
 - package.json with TypeScript, Jest, ESLint, Prettier
 - tsconfig.json
 - .github/workflows/ci.yml
@@ -74,10 +74,11 @@ Claude: Done. Your project is set up:
 
 - All checks pass (typecheck, lint, tests)
 - Initial commit created
-- 6 slash commands ready to use
+- 7 slash commands ready to use
 
 You can start with /research to explore any existing patterns,
-or /plan to design your first feature.
+or /plan to design your first feature. For a brand-new idea with no
+spec yet, /brainstorm turns it into a design brief first.
 ```
 
 ---

--- a/methodology/four-phases.md
+++ b/methodology/four-phases.md
@@ -10,6 +10,9 @@
 ```
 User
  │
+ ├── /brainstorm ────► Brainstorm Facilitator (optional pre-step)
+ │                       └── Socratic Q&A with user → design brief
+ │
  ├── /research  ─────► Research Orchestrator
  │                       ├── Codebase Locator (find WHERE)
  │                       ├── Codebase Analyzer (understand HOW)

--- a/methodology/four-phases.md
+++ b/methodology/four-phases.md
@@ -1,5 +1,10 @@
 # The Four Phases
 
+> Optional pre-step: when the work starts as a vague idea rather than a spec,
+> `/brainstorm` precedes Research. It is an interactive Socratic intake that
+> produces a design brief in `docs/research/`, not a phase of the pipeline
+> below. Skip it whenever the task is already well-specified.
+
 ## Architecture Overview
 
 ```

--- a/templates/commands/bootstrap.md
+++ b/templates/commands/bootstrap.md
@@ -36,7 +36,7 @@ Now execute the setup checklist against THIS project. Work through it section by
 5. Create `.claude/settings.json` — adapt from the template.
 6. Create `.claude/commands/` — copy slash commands from `cc-rpi/templates/commands/` and adjust file paths.
 7. Install skills from `cc-rpi/templates/skills/` to `.claude/skills/`:
-   - Always install: `git-workflow/`, `multi-agent/`, `deployment-safety/`, `ci-workflow/`, `github-cli/`, `error-patterns/`
+   - Always install: `git-workflow/`, `multi-agent/`, `deployment-safety/`, `ci-workflow/`, `github-cli/`, `error-patterns/`, `systematic-debugging/`
    - If Python project: also install `python-rules/`
    - If macOS development: also install `macos-rules/`
    - If using Supabase: also install `supabase/`

--- a/templates/commands/brainstorm.md
+++ b/templates/commands/brainstorm.md
@@ -1,0 +1,77 @@
+Refine a raw idea into a validated design brief: $ARGUMENTS
+
+Model tier: **opus** — Opus session. Conversational reasoning, no subagents by default.
+
+The front end of RPI for greenfield or vague work. `/research` documents an
+existing codebase; `/brainstorm` interrogates an idea that does not exist yet and
+produces a design brief that `/plan` can consume. Use it when the request is a
+goal, not a spec — when you could not yet write success criteria.
+
+## When to use
+
+- Greenfield feature or project with no clear spec.
+- A vague request ("we should make X better") where scope is undefined.
+- Skip it when the task is well-specified, mechanical, or already researched.
+  Go straight to `/plan` (existing code) or `/research` (understand first).
+
+## Process
+
+1. Restate the idea in one sentence and name the core uncertainty. If the
+   one-liner is obvious and unambiguous, say so and recommend skipping to
+   `/plan` — do not manufacture questions.
+2. Ask ONE focused question at a time. Wait for the answer before the next.
+   Never batch a wall of questions. Socratic, not a survey.
+3. Cover the dimensions that change the design, in roughly this order:
+   - **Problem**: who has it, what do they do today, why now.
+   - **Scope**: what is explicitly IN and OUT of this effort.
+   - **Constraints**: stack, deadlines, existing systems, non-negotiables.
+   - **Success**: how we will know it worked — concrete, observable.
+   - **Risks**: what could make this the wrong thing to build.
+4. Present design options as they emerge — at least two, with honest
+   trade-offs. Recommend one. Do not hide the alternatives.
+5. Reflect understanding back in digestible chunks. Confirm each chunk before
+   moving on. Surface disagreements early, not at the end.
+6. When the uncertainty is resolved, write the design brief.
+
+## Output
+
+Save to `docs/research/YYYY-MM-DD-[description]-brief.md` (same directory `/plan`
+reads from). Structure:
+
+```markdown
+# Design Brief: [name]
+> Brainstormed on [date]
+
+## Problem
+[Who, what they do today, why now]
+
+## Goal
+[One sentence]
+
+## Scope
+**In:** [...]
+**Out:** [...]
+
+## Constraints
+[Stack, deadlines, existing systems, non-negotiables]
+
+## Chosen Approach
+[The recommended option and WHY, with the rejected alternatives and why not]
+
+## Success Criteria
+[Concrete, observable — these become the plan's success criteria]
+
+## Open Risks
+[What could still make this wrong]
+```
+
+## Rules
+
+- Ask one question at a time. Never dump a questionnaire.
+- Do not write code, do not plan implementation phases — that is `/plan`'s job.
+- Do not invent requirements the user never stated. If something is unknown,
+  it stays an open question; never paper over a gap with a placeholder.
+- Present trade-offs, not a single railroaded answer.
+- A brief with unresolved core uncertainty is not done. Resolve it or flag it
+  explicitly as a blocking open question and **STOP**.
+- Hand off: when the brief is written, tell the user the next step is `/plan`.

--- a/templates/setup-checklist.md
+++ b/templates/setup-checklist.md
@@ -108,6 +108,7 @@ Committed.
 ## Slash Commands
 
 Copy and adapt from `templates/commands/`:
+- [ ] `/brainstorm` — Optional Socratic pre-step for vague/greenfield ideas (feeds `/plan`)
 - [ ] `/research` — Codebase research with parallel subagents
 - [ ] `/plan` — Interactive plan creation with phases
 - [ ] `/implement` — Phase-by-phase execution with review gates
@@ -128,7 +129,7 @@ the matching slash-style command.
 
 - [ ] Create `.claude/skills/` directory
 - [ ] Copy blueprint skills from `cc-rpi/templates/skills/` to `.claude/skills/`:
-  - Always: `git-workflow/`, `multi-agent/`, `deployment-safety/`, `ci-workflow/`, `github-cli/`, `error-patterns/`
+  - Always: `git-workflow/`, `multi-agent/`, `deployment-safety/`, `ci-workflow/`, `github-cli/`, `error-patterns/`, `systematic-debugging/`
   - Python projects: also `python-rules/`
   - macOS development: also `macos-rules/`
   - Supabase projects: also `supabase/`

--- a/templates/skills/systematic-debugging/SKILL.md
+++ b/templates/skills/systematic-debugging/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: "Systematic Debugging"
+description: "A disciplined procedure for finding root causes -- reproduce, isolate, hypothesize, bisect, fix, verify. Consult when a bug is non-obvious, a fix didn't hold, or you've tried the same thing twice without progress."
+user-invocable: false
+---
+
+# Systematic Debugging
+
+When stuck, stop guessing. Run the loop. Random edits that "might fix it"
+waste turns and mask the real cause. For known tool/git/CI failures, check the
+Error Patterns skill first — this skill is for novel bugs.
+
+## The Loop
+
+1. **Reproduce.** Get a reliable, minimal repro before changing anything. A bug
+   you cannot reproduce on demand, you cannot confirm fixed. Note the exact
+   command, inputs, and expected-vs-actual.
+2. **Isolate.** Shrink the surface. Remove inputs, comment out code, halve the
+   data until the smallest thing that still fails remains. `git bisect` when a
+   regression has a known-good past commit.
+3. **Hypothesize.** State ONE specific, falsifiable cause: "X is null because Y
+   runs before Z." If you cannot name a mechanism, you are still guessing.
+4. **Test the hypothesis.** Add a log/breakpoint/assertion that the hypothesis
+   predicts. Observe. Confirm or kill it before touching the fix.
+5. **Fix the root cause.** Not the symptom. If the fix is "add a null check,"
+   ask why it is null — that is usually the real bug.
+6. **Verify.** Re-run the repro from step 1. Then run the surrounding tests to
+   confirm you broke nothing. A fix unconfirmed against the original repro is
+   not a fix.
+
+## Discipline
+
+- **Read the actual error.** Full message, full stack trace, top to bottom. The
+  answer is in there more often than not. Don't skim to the first familiar line.
+- **One change at a time.** Change-everything-and-pray destroys the signal about
+  what actually mattered. Revert failed experiments before the next one.
+- **Trust nothing, verify everything.** Don't assume which function runs, what a
+  variable holds, or that a dependency is installed. Add the log and look.
+- **Bisect over speculation.** When a thing used to work, the diff that broke it
+  is findable mechanically. Don't theorize about a regression you can bisect.
+- **Question the assumption, not just the code.** If reality contradicts your
+  mental model, the model is wrong. Find which assumption is false.
+
+## Stop conditions
+
+- Same approach twice with no new information -> stop, change technique, or
+  escalate. Repeating a failed action is Error #-class behavior.
+- Fix doesn't hold after verify -> the hypothesis was wrong. Return to step 3
+  with what you just learned. Do not pile a second guess on top.
+- Root cause genuinely unclear after the loop -> surface what you ruled out and
+  what remains, and ask. A documented dead end beats a silent wrong fix.


### PR DESCRIPTION
## v1.21.0

Three deliverables plus a documentation consistency sweep.

### Added
- **Installable as a Claude Code plugin.** `.claude-plugin/plugin.json` +
  `marketplace.json` make the repo its own self-hosted marketplace
  (`/plugin marketplace add juan294/cc-rpi`). Manifest points `skills`/`commands`
  at the existing `templates/` dirs -- no file moves; blueprint/copy model
  unchanged. Passes `claude plugin validate`.
- **`/brainstorm` command** -- optional Socratic RPI pre-step that turns a
  vague/greenfield idea into a design brief for `/plan`.
- **`systematic-debugging` skill** -- auto-consulted reproduce -> isolate ->
  hypothesize -> test -> fix-root-cause -> verify loop (skills 9 -> 10).

### Changed
- Documentation consistency sweep: `/bootstrap` + `setup-checklist.md` install
  the new skill and list `/brainstorm`; GUIDE skill count 9 -> 10; four-phases
  topology diagram shows `/brainstorm`; bootstrap example count fixed.

### Fixed
- Nightly `cc-rpi-update` agent now uses `--permission-mode bypassPermissions`
  so headless `.claude/` edits aren't blocked.

Full details in CHANGELOG.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)