### PR TITLE
feat(contract): contract-layer enforcement harness (Rule #77)

### DIFF
--- a/.claude/commands/pre-launch.md
+++ b/.claude/commands/pre-launch.md
@@ -149,6 +149,11 @@ Rules:
 - Prefer systemic findings: one pattern covering 5 instances > five
   separate nitpicks.
 
+This contract is machine-checkable: `/remediate` runs
+`.claude/scripts/validate-findings.py` against the report before parsing and
+rejects any finding with a malformed Finding-ID, a missing required field, or
+no `file:line` ref. Emit findings in exactly this format.
+
 ### Cross-Domain Notes (optional)
 
 Findings touching another specialist's domain — noted briefly, referenced

--- a/.claude/commands/remediate.md
+++ b/.claude/commands/remediate.md
@@ -28,6 +28,19 @@ Gather context before making any changes.
    QA, UX). Section 14 (Before/After/Later) is the wave-ordering index.
    Section 15 (Open Questions) is NOT findings — skip it.
 
+   **Validate the report contract first** (deterministic gate, before any
+   parsing):
+
+   ```bash
+   python3 .claude/scripts/validate-findings.py <report-path>
+   ```
+
+   Exit 0 — findings satisfy the Output Contract; proceed. Non-zero — the
+   report has malformed findings (bad Finding-ID, missing required field, or
+   no `file:line`). **STOP** and report exactly which findings the validator
+   named. Do not parse a broken report: the consumer regex below would
+   silently drop the malformed ones, violating Rule #58 (100% coverage).
+
 2. **Extract EVERY finding** — all 5 severity tiers: launch-blocker,
    high, medium, low, strategic. No filtering by severity — Rule #58
    100% coverage.
@@ -36,6 +49,7 @@ Gather context before making any changes.
 
    - Findings are the `#### <Finding-ID> <Title>` blocks in §4-§11.
    - Finding ID regex: `(AR|FE|BE|PE|DO|SE|QA|UX)-(B|H|M|L|S)[0-9]+`
+     (machine-checked by `validate-findings.py` in step 1).
    - Each finding has structured fields (bold format:
      `**Severity:**`, `**Time horizon:**`, `**Evidence type:**`,
      `**Files:**`, `**What's happening:**`, `**Why it matters:**`,

--- a/.claude/hooks/guard-bash.sh
+++ b/.claude/hooks/guard-bash.sh
@@ -8,6 +8,10 @@
 # Input:    JSON on stdin: { "tool_name": "Bash", "tool_input": { "command": "..." } }
 # Output:   exit 0 = allow, exit 2 = block (stdout shown to agent as reason)
 #
+# Block messages use the corrective-hint convention (BLOCKED / WHY / FIX) via
+# emit_block — a block is a guided correction, not just a stop. See
+# methodology/ci-and-guardrails.md "Block messages are corrective hints".
+#
 # Add project-specific guards at the bottom of this file.
 
 # Intentionally no `set -e` — this script is fail-open by design.
@@ -15,6 +19,12 @@
 # execution falls through to exit 0 and the command is allowed.
 # A guard hook must never block legitimate work due to its own bugs.
 set -uo pipefail
+
+# emit_block <hook> <reason> <why> <fix> — print a corrective-hint block.
+# $4 (fix) may be multi-line; keep its own indentation.
+emit_block() {
+  printf 'BLOCKED by %s — %s\n\nWHY: %s\n\nFIX:\n%s\n' "$1" "$2" "$3" "$4"
+}
 
 # Require jq for JSON parsing — allow through if unavailable
 if ! command -v jq &>/dev/null; then
@@ -34,13 +44,10 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 # Agent edits files, then runs git pull --rebase without committing first.
 if [[ "$COMMAND" == *"git pull"* ]] && [[ "$COMMAND" == *"--rebase"* ]]; then
   if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
-    echo "BLOCKED by guard-bash.sh — Error #33: uncommitted changes"
-    echo ""
-    echo "git pull --rebase will fail with a dirty working tree."
-    echo "Commit or stash first, then pull:"
-    echo ""
-    echo "  git add <files> && git commit -m \"msg\""
-    echo "  git pull --rebase && git push"
+    emit_block "guard-bash.sh" "Error #33: uncommitted changes" \
+      "git pull --rebase fails with a dirty working tree." \
+      "  git add <files> && git commit -m \"msg\"
+  git pull --rebase && git push"
     exit 2
   fi
 fi
@@ -53,13 +60,10 @@ if [[ "$COMMAND" == *"git push"* ]]; then
   # Error #44: --tags pushes ALL local tags, not just the new one.
   # Old tags that already exist on remote cause a non-zero exit code.
   if [[ "$COMMAND" == *"--tags"* ]] && [[ "$COMMAND" != *"--follow-tags"* ]]; then
-    echo "BLOCKED by guard-bash.sh — Error #44: --tags pushes all local tags"
-    echo ""
-    echo "--tags pushes every tag, not just new ones. Old tags cause failures."
-    echo "Push specific tags or use --follow-tags:"
-    echo ""
-    echo "  git push origin main && git push origin v1.0.0"
-    echo "  git push origin main --follow-tags"
+    emit_block "guard-bash.sh" "Error #44: --tags pushes all local tags" \
+      "--tags pushes every tag, not just new ones; old tags cause failures." \
+      "  git push origin main && git push origin v1.0.0
+  git push origin main --follow-tags"
     exit 2
   fi
 
@@ -68,10 +72,14 @@ if [[ "$COMMAND" == *"git push"* ]]; then
   # main, so validated changes may still be pushed there after explicit user
   # approval. The policy is "high-stakes and exceptional", not "never".
   # The template at templates/hooks/guard-bash.sh keeps the generic guard for
-  # repos where production/main protection should be enforced directly.
+  # repos where production/main protection should be enforced directly:
   # if [[ "$COMMAND" =~ (^|[[:space:]])(main|master)($|[[:space:]]|:) ]] \
   #    && [[ "$COMMAND" != *"--follow-tags"* ]]; then
-  #   echo "BLOCKED by guard-bash.sh — Error #48: direct push to protected branch"
+  #   emit_block "guard-bash.sh" "Error #48: direct push to protected branch" \
+  #     "Pushing directly to main/master is a high-stakes action." \
+  #     "  git push origin develop                 # develop/main topology
+  # git push -u origin feature/my-change    # main-only or PR flow
+  # git push origin main --follow-tags      # releases with tags (ask first)"
   #   exit 2
   # fi
 
@@ -82,8 +90,9 @@ fi
 
 # Example: block bare python3 (uncomment for Python/uv projects)
 # if [[ "$COMMAND" =~ ^python3?[[:space:]] ]] && [[ "$COMMAND" != *"uv run"* ]] && [[ "$COMMAND" != *"poetry run"* ]]; then
-#   echo "BLOCKED — use 'uv run python' instead of bare 'python3'"
-#   echo "System Python doesn't have project dependencies."
+#   emit_block "guard-bash.sh" "Rule #44: bare python3" \
+#     "System Python doesn't have project dependencies." \
+#     "  uv run python <args>"
 #   exit 2
 # fi
 

--- a/.claude/hooks/verify-edit.sh
+++ b/.claude/hooks/verify-edit.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# verify-edit.sh — PostToolUse hook for Write/Edit on markdown files.
+#
+# Post-action verification: a deterministic check that runs AFTER an edit lands
+# and surfaces violations back to the agent so it fixes them immediately, instead
+# of waiting for CI. Realizes "Level 1: Editor-time" from
+# methodology/ci-and-guardrails.md for the Claude Code harness.
+#
+# Location: .claude/hooks/verify-edit.sh (in projects)
+# Config:   .claude/settings.json → hooks.PostToolUse (matcher "Write|Edit")
+# Input:    JSON on stdin: { "tool_name": "...", "tool_input": { "file_path": "..." } }
+# Output:   exit 0 = ok, exit 2 = surface the corrective hint to the agent.
+#
+# NOTE: PostToolUse cannot prevent the write — the edit already landed. exit 2
+# feeds the hint to the agent as "fix this now". The hard gate stays CI/pre-commit.
+#
+# Checks:
+#   1. No emojis in docs (always on; per-file opt-out via <!-- contract:allow-emoji -->)
+#   2. markdownlint — ONLY when the project ships a markdownlint config (otherwise
+#      default rules flood false positives on repos that never opted into linting).
+
+# Fail-open by design — see guard-bash.sh. Any tooling gap → allow through.
+set -uo pipefail
+
+# emit_block <reason> <why> <fix> — corrective-hint convention (BLOCKED/WHY/FIX).
+emit_block() {
+  printf 'BLOCKED by verify-edit.sh — %s\n\nWHY: %s\n\nFIX:\n%s\n' "$1" "$2" "$3"
+}
+
+command -v jq &>/dev/null || exit 0
+
+read -r -d '' INPUT || true
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+# Only Write/Edit on markdown files.
+[[ "$TOOL" == "Write" || "$TOOL" == "Edit" ]] || exit 0
+[[ "$FILE" == *.md ]] || exit 0
+[[ -f "$FILE" ]] || exit 0
+
+
+# ─── Check 1: emoji in documentation ──────────────────────────────────────
+# Per-file opt-out for files that must show an emoji as a literal example.
+if ! grep -q 'contract:allow-emoji' "$FILE" 2>/dev/null && command -v perl &>/dev/null; then
+  # Ranges target true emoji/pictographs. Deliberately EXCLUDE arrows
+  # (U+2190-21FF, e.g. →), em-dash (U+2014), and box-drawing (U+2500-257F),
+  # all of which cc-rpi docs use legitimately.
+  HITS=$(perl -CSD -ne \
+    'while (/([\x{1F000}-\x{1FAFF}\x{2600}-\x{27BF}\x{2B00}-\x{2BFF}\x{FE0F}])/g) {
+       printf "    line %d: U+%04X\n", $., ord($1) }' "$FILE" 2>/dev/null)
+  if [[ -n "$HITS" ]]; then
+    emit_block "no emojis in documentation" \
+      "Project policy: docs use text equivalents (PASS, [x], ->), not emoji." \
+      "  Remove the emoji at:
+$HITS
+  (Only if a glyph is a required literal example, add a line containing
+  <!-- contract:allow-emoji --> to this file to skip this check.)"
+    exit 2
+  fi
+fi
+
+
+# ─── Check 2: markdownlint (config-gated) ─────────────────────────────────
+MDL_CONFIG=""
+for c in .markdownlint.json .markdownlint.jsonc .markdownlint.yaml .markdownlint.yml .markdownlintrc; do
+  [[ -f "$c" ]] && MDL_CONFIG="$c" && break
+done
+# Probe that markdownlint actually runs — otherwise a "tool not found" exit
+# would be misread as lint violations and falsely block. Fail-open if absent.
+if [[ -n "$MDL_CONFIG" ]] && command -v npx &>/dev/null \
+   && npx --no-install markdownlint --version &>/dev/null; then
+  if ! LINT=$(npx --no-install markdownlint "$FILE" 2>&1); then
+    NL=$'\n'
+    emit_block "markdownlint violations" \
+      "Lint errors fail CI; fix them at edit time, not at push." \
+      "    ${LINT//$NL/$NL    }"
+    exit 2
+  fi
+fi
+
+
+exit 0

--- a/.claude/scripts/validate-findings.py
+++ b/.claude/scripts/validate-findings.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""validate-findings.py — enforce the pre-launch Output Contract.
+
+The pre-launch report declares a finding format (Finding-ID grammar + required
+fields) that /remediate parses. Today that contract is prose: a malformed finding
+is silently dropped by the consumer regex. This validator makes the contract
+machine-checkable — it rejects a report whose findings violate the grammar, are
+missing required fields, or lack a file:line ref ("no refs = no finding").
+
+Usage:
+    validate-findings.py <report.md>     # exit 0 if valid, 1 if violations
+    validate-findings.py --self-test     # run bundled fixtures, exit 0/1
+
+Stdlib only. Spec: pre-launch.md "Output Contract", remediate.md "Parser contract".
+"""
+
+import argparse
+import os
+import re
+import sys
+
+# Strict Finding-ID grammar (must match the /remediate consumer regex).
+ID_VALID = re.compile(r"^(AR|FE|BE|PE|DO|SE|QA|UX)-(B|H|M|L|S)[0-9]+$")
+# Loose "looks like someone tried to write a Finding-ID" — used to detect
+# malformed IDs (lowercase, wrong severity letter, etc.) that the consumer
+# would silently drop.
+ID_SHAPED = re.compile(r"^[A-Za-z]{2}-[A-Za-z]?[0-9]+")
+# A file:line reference, e.g. src/app.ts:42 or path/x.py:110-130.
+FILELINE = re.compile(r"\S+:[0-9]+")
+
+REQUIRED_FIELDS = [
+    "Severity",
+    "Time horizon",
+    "Evidence type",
+    "Files",
+    "What's happening",
+    "Why it matters",
+    "Recommendation",
+    "Expected impact",
+    "Effort estimate",
+]
+
+
+class Block:
+    def __init__(self, heading_line):
+        self.heading = heading_line.rstrip("\n")
+        self.body_lines = []
+
+    @property
+    def first_token(self):
+        # "#### SE-B1 Title" -> "SE-B1"
+        parts = self.heading[4:].strip().split()
+        return parts[0] if parts else ""
+
+    @property
+    def body(self):
+        return "\n".join(self.body_lines)
+
+    def field_value(self, name):
+        # Return the text after "**Name:**" on its line, or None.
+        m = re.search(
+            r"\*\*" + re.escape(name) + r":\*\*(.*)",
+            self.body,
+        )
+        return m.group(1).strip() if m else None
+
+
+def parse_blocks(text):
+    """Yield every #### block in the document (heading + following lines up to
+    the next #### or ## heading)."""
+    blocks = []
+    current = None
+    for line in text.splitlines(keepends=True):
+        if line.startswith("#### "):
+            current = Block(line)
+            blocks.append(current)
+        elif line.startswith("## ") or line.startswith("# "):
+            current = None  # left the block
+        elif current is not None:
+            current.body_lines.append(line.rstrip("\n"))
+    return blocks
+
+
+def is_finding_candidate(block):
+    """A #### block we should hold to the contract: it either attempts a
+    Finding-ID or carries finding fields (so a dropped one is a real loss)."""
+    return bool(ID_SHAPED.match(block.first_token)) or (
+        "**Severity:**" in block.body
+    )
+
+
+def validate_text(text):
+    """Return a list of (finding-label, reason) violations."""
+    errors = []
+    for block in parse_blocks(text):
+        if not is_finding_candidate(block):
+            continue
+        label = block.first_token or block.heading.strip()
+        if not ID_VALID.match(block.first_token):
+            errors.append(
+                (label, "invalid or missing Finding-ID "
+                        "(want <AR|FE|BE|PE|DO|SE|QA|UX>-<B|H|M|L|S><n>)")
+            )
+        for field in REQUIRED_FIELDS:
+            if f"**{field}:**" not in block.body:
+                errors.append((label, f"missing required field: {field}"))
+        files = block.field_value("Files")
+        if files is not None and not FILELINE.search(files):
+            errors.append(
+                (label, "no file:line ref in Files (no refs = no finding)")
+            )
+    return errors
+
+
+def validate_file(path):
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        return validate_text(fh.read())
+
+
+# --- bundled fixtures for --self-test -------------------------------------
+
+VALID_FIXTURE = """## 5. Backend
+
+#### BE-H1 N+1 query in the orders endpoint
+- **Severity:** high
+- **Time horizon:** Before launch
+- **Evidence type:** [evidence]
+- **Files:** src/orders/api.ts:42, src/orders/repo.ts:110-130
+- **What's happening:** the list endpoint issues one query per row.
+- **Why it matters:** p95 latency scales with result size.
+- **Recommendation:** batch the lookups with a single join.
+- **Expected impact:** flat latency under load.
+- **Effort estimate:** M
+
+## 6. Performance
+
+### Domain Model
+Plain prose, not a finding.
+"""
+
+INVALID_FIXTURE = """## 5. Backend
+
+#### be-h1 lowercase id is malformed
+- **Severity:** high
+- **Time horizon:** Before launch
+- **Evidence type:** [evidence]
+- **Files:** src/orders/api.ts:42
+- **What's happening:** x
+- **Why it matters:** y
+- **Recommendation:** z
+- **Expected impact:** w
+- **Effort estimate:** M
+
+#### SE-B1 missing fields and no file:line
+- **Severity:** launch-blocker
+- **Files:** src/auth/login.ts
+- **Why it matters:** y
+"""
+
+
+def self_test():
+    ok = True
+    valid_errs = validate_text(VALID_FIXTURE)
+    if valid_errs:
+        ok = False
+        print("SELF-TEST FAIL: valid fixture reported errors:")
+        for label, reason in valid_errs:
+            print(f"  {label}: {reason}")
+    else:
+        print("SELF-TEST PASS: valid fixture clean")
+
+    invalid_errs = validate_text(INVALID_FIXTURE)
+    # Expect: bad ID on be-h1, plus SE-B1 missing several fields + no file:line.
+    labels = {label for label, _ in invalid_errs}
+    expect_bad_id = any(
+        "invalid or missing Finding-ID" in r for _, r in invalid_errs
+    )
+    expect_missing = any("missing required field" in r for _, r in invalid_errs)
+    expect_noref = any("no file:line ref" in r for _, r in invalid_errs)
+    if invalid_errs and expect_bad_id and expect_missing and expect_noref:
+        print(f"SELF-TEST PASS: invalid fixture flagged "
+              f"{len(invalid_errs)} violations across {sorted(labels)}")
+    else:
+        ok = False
+        print("SELF-TEST FAIL: invalid fixture not fully flagged:")
+        for label, reason in invalid_errs:
+            print(f"  {label}: {reason}")
+    return ok
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", nargs="?", help="path to the pre-launch report")
+    parser.add_argument("--self-test", action="store_true",
+                        help="run bundled fixtures and exit")
+    args = parser.parse_args()
+
+    if args.self_test:
+        sys.exit(0 if self_test() else 1)
+
+    if not args.report:
+        parser.error("a report path is required (or use --self-test)")
+    if not os.path.isfile(args.report):
+        print(f"ERROR: report not found: {args.report}", file=sys.stderr)
+        sys.exit(2)
+
+    errors = validate_file(args.report)
+    if errors:
+        print(f"CONTRACT VIOLATION: {len(errors)} issue(s) in {args.report}",
+              file=sys.stderr)
+        for label, reason in errors:
+            print(f"  {label}: {reason}", file=sys.stderr)
+        sys.exit(1)
+    print(f"OK: report findings satisfy the Output Contract ({args.report})")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/verify-edit.sh"
+          }
+        ]
+      }
     ]
   },
   "permissions": {

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -50,9 +50,19 @@ jobs:
           rm "$errfile"
           echo "All internal markdown links valid"
 
-      # --- ShellCheck on script templates ---
+      # --- ShellCheck on script + hook templates ---
       - name: Lint shell scripts
-        run: shellcheck --severity=warning templates/scripts/cc-rpi-update-agent.sh
+        run: |
+          shellcheck --severity=warning \
+            templates/scripts/cc-rpi-update-agent.sh \
+            templates/hooks/guard-bash.sh \
+            templates/hooks/verify-edit.sh
+
+      # --- Findings-contract validator self-test ---
+      - name: Validate findings-contract validator
+        run: |
+          python3 -m py_compile templates/scripts/validate-findings.py
+          python3 templates/scripts/validate-findings.py --self-test
 
       # --- JSON syntax validation ---
       - name: Validate JSON files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,3 +68,10 @@ When the user invokes a slash-style command:
   committed history; `docs/agents/` is operational output whose commit
   policy depends on repo visibility (Rule #70) -- gitignored on public
   repos, tracked on private repos as a historical audit trail
+- **Contract layer.** The `PostToolUse` hook `verify-edit.sh` (emoji +
+  markdownlint on `.md` edits) is Claude-Code-specific -- Codex will not run
+  it, so apply Rule #77 (no emojis in docs) by hand. The validator
+  `.claude/scripts/validate-findings.py` IS portable: run it on any
+  pre-launch report before parsing in a `/remediate`-style flow, and STOP if
+  it exits non-zero. When a guard blocks, phrase the reason as
+  `BLOCKED / WHY / FIX` with a runnable fix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Contract layer (post-action verification).** A targeted set of deterministic
+  guardrails that move the mechanically-detectable subset of rules from advisory
+  prose to hard enforcement:
+  - `templates/hooks/verify-edit.sh` — a `PostToolUse` hook on `Write`/`Edit`
+    that checks edited `.md` files for emoji (always on; per-file opt-out via
+    `<!-- contract:allow-emoji -->`) and runs markdownlint when the project ships
+    a markdownlint config. cc-rpi's first post-action verification layer; realizes
+    "Level 1: Editor-time" from `methodology/ci-and-guardrails.md`.
+  - Standardized `BLOCKED / WHY / FIX` corrective-hint format across hooks (shared
+    `emit_block` helper in `guard-bash.sh` and `verify-edit.sh`) so every block is
+    a guided correction.
+  - `templates/scripts/validate-findings.py` — enforces the pre-launch/remediate
+    Finding-ID contract (grammar, required fields, `file:line` rule); `/remediate`
+    runs it as a Step-1 gate before parsing, rejecting malformed reports.
+  - New Rule #77 ("No emojis in documentation", `[hook-enforced]`). Rule count
+    76 -> 77.
+  - Inspired by `cristhianrivera/contract-driven-llm-agent` (idea source only —
+    no SQL/ontology/reconciler machinery ported).
+
 ## [1.21.0] - 2026-06-19
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Blueprint repository for Claude Code projects, with Codex compatibility
 via `AGENTS.md` plus Codex-only helper skills in `.codex/skills/`.
-Contains the RPI methodology, 63 known agent error patterns, 76
+Contains the RPI methodology, 63 known agent error patterns, 77
 operational rules, and templates for CLAUDE.md, AGENTS.md, slash
 commands, skills, rules, and project setup.
 
@@ -88,7 +88,7 @@ Go directly to these paths -- never search the codebase for them.
 | Topic | Path | Notes |
 |-------|------|-------|
 | Error catalog | `patterns/agent-errors.md` | 63 errors, source of truth |
-| Operational rules | `patterns/quick-reference.md` | 76 rules with scope/stack tags |
+| Operational rules | `patterns/quick-reference.md` | 77 rules with scope/stack tags |
 | Deployment safety | `patterns/deployment-safety.md` | Resource efficiency rules |
 | Skill templates | `templates/skills/` | 10 domain skills |
 | Codex-only skills | `.codex/skills/` | Personal Codex helpers such as `codex-simplify` |
@@ -97,7 +97,8 @@ Go directly to these paths -- never search the codebase for them.
 | Methodology | `methodology/` | 12 files, order in README.md |
 | Commands | `templates/commands/` | Canonical command definitions |
 | Active commands | `.claude/commands/` | This repo's own commands |
-| Hooks | `templates/hooks/guard-bash.sh` | Template; `.claude/hooks/` active |
+| Hooks | `templates/hooks/guard-bash.sh` (PreToolUse), `templates/hooks/verify-edit.sh` (PostToolUse) | Templates; `.claude/hooks/` active |
+| Contract validator | `templates/scripts/validate-findings.py` | Enforces pre-launch/remediate Finding-ID contract; `.claude/scripts/` active |
 | Research | `docs/research/YYYY-MM-DD-*.md` | RPI research about cc-rpi |
 | Plans | `docs/plans/YYYY-MM-DD-*.md` | RPI plans for cc-rpi |
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -311,7 +311,7 @@ This sounds restrictive, but it's the single most impactful rule for research qu
 
 ### Error Prevention
 
-The blueprint includes 76 operational rules learned from real sessions. These aren't theoretical — they're patterns that caused actual failures and wasted time. Rather than loading all rules into every session, the blueprint uses **progressive disclosure** across three layers: a slim CLAUDE.md (~70 lines) for universal instructions, `.claude/rules/` for conditional rules that load only when working with matching files, and `.claude/skills/` for detailed domain knowledge that loads on demand. This keeps the agent's context window clean and focused.
+The blueprint includes 77 operational rules learned from real sessions. These aren't theoretical — they're patterns that caused actual failures and wasted time. Rather than loading all rules into every session, the blueprint uses **progressive disclosure** across three layers: a slim CLAUDE.md (~70 lines) for universal instructions, `.claude/rules/` for conditional rules that load only when working with matching files, and `.claude/skills/` for detailed domain knowledge that loads on demand. This keeps the agent's context window clean and focused.
 
 The 10 blueprint-provided skills cover: git workflow, CI verification, deployment safety, multi-agent coordination, GitHub CLI, Python, macOS, Supabase, error patterns, and systematic debugging. The 5 rule templates cover: RPI details, push accountability, deployment safety, Supabase, and testing.
 
@@ -368,6 +368,8 @@ your-project/
 ├── CLAUDE.md                    # Project configuration (Claude reads this every session)
 ├── .claude/
 │   ├── settings.json            # Tool permissions, Agent Teams, hooks
+│   ├── hooks/                   # guard-bash.sh (PreToolUse), verify-edit.sh (PostToolUse)
+│   ├── scripts/                 # validate-findings.py (pre-launch/remediate contract)
 │   ├── commands/                # Slash commands (user-invoked workflows)
 │   │   ├── research.md          # /research
 │   │   ├── plan.md              # /plan
@@ -456,7 +458,7 @@ The blueprint repository contains detailed documentation on every topic mentione
 | CI ownership | `methodology/push-accountability.md` | Background CI monitoring, fix-and-repush |
 | Model economics | `methodology/cost-monitoring.md` | Cost pools, model-tier binding, access tiers, cost-per-outcome |
 | Error patterns | `patterns/agent-errors.md` | 63 documented errors with symptoms and solutions |
-| Operational rules | `patterns/quick-reference.md` | 76 rules with scope/stack tags, organized by domain |
+| Operational rules | `patterns/quick-reference.md` | 77 rules with scope/stack tags, organized by domain |
 | Domain skills | `templates/skills/` | 10 blueprint-provided skills for progressive disclosure |
 | Rule templates | `templates/rules/` | 5 conditional/modular rules for `.claude/rules/` |
 | Deployment safety | `patterns/deployment-safety.md` | Resource efficiency and production deployment rules |

--- a/methodology/ci-and-guardrails.md
+++ b/methodology/ci-and-guardrails.md
@@ -77,18 +77,89 @@ Only promote a rule to hook enforcement when:
 The current guard script enforces:
 - **Error #33**: `git pull --rebase` with uncommitted changes (checks `git status --porcelain`)
 - **Error #44**: `git push --tags` instead of specific tag names (pattern match)
+- **Error #48**: direct push to `main`/`master` (template default; commented out in cc-rpi's own copy, where `main` is the long-lived branch)
+
+### Block messages are corrective hints
+
+Criterion 3 above ("has a clear fix") is not advice — it is a required output
+format. Every block a hook emits follows the same shape so a block is a guided
+correction, not just a stop:
+
+```
+BLOCKED by <hook> — <Rule/Error #N>: <one-line reason>
+
+WHY: <one sentence on the consequence if allowed>
+
+FIX:
+  <copy-pasteable command or concrete instruction>
+```
+
+Hooks build this with a shared `emit_block <hook> <reason> <why> <fix>` helper
+(see `templates/hooks/guard-bash.sh`). The `FIX` block must be runnable as-is.
+This mirrors the deterministic "retry hint" idea from contract-driven agent
+designs — when enforcement moves out of the prompt and into code, the code still
+has to tell the agent exactly how to comply. (Idea source:
+`cristhianrivera/contract-driven-llm-agent` — convention only, no machinery ported.)
 
 ### Three-Tier Error Prevention Model
 
 | Tier | Mechanism | Reliability | When to Use |
 |------|-----------|-------------|-------------|
-| **Enforce** | PreToolUse hooks, pre-commit hooks, CI | High — mechanically prevented | Top repeat offenders. Rules that keep getting violated despite documentation. |
+| **Enforce** | PreToolUse hooks, PostToolUse verification, pre-commit hooks, CI | High — mechanically prevented | Top repeat offenders. Rules that keep getting violated despite documentation. |
 | **Prompt** | Command recipes in CLAUDE.md | Medium — agent copies the pattern | Frequent operations. Give compound commands to copy instead of compose. |
 | **Document** | agent-errors.md, quick-reference.md | Low — advisory only | Long tail. Reference for when things go wrong. |
 
 Rules graduate upward: a pattern documented in tier 3 that keeps recurring gets promoted to tier 2 (recipe in CLAUDE.md) or tier 1 (hook). The error processing routine should track repeat offenders across batches and promote accordingly.
 
 Skills can extend this model with **on-demand hooks** — guardrails that activate only when a specific skill is invoked and last for the session. Use these for rules too restrictive to run permanently but essential in certain contexts (e.g., blocking destructive commands when touching production). See [agent-design.md](agent-design.md) "On-Demand Hooks" for examples.
+
+## Agent Tool Hooks (Level 1: post-edit verification)
+
+Level 0 hooks prevent bad commands *before* they run. The harness realizes
+**Level 1 (editor-time)** with a `PostToolUse` hook on `Write`/`Edit`:
+`templates/hooks/verify-edit.sh`. After an edit lands, it checks the file and
+surfaces violations as a corrective hint so the agent fixes them immediately —
+instead of discovering them at CI.
+
+This is post-action verification: a deterministic check that runs *after*
+generation, the most transferable idea from contract-driven agent designs. Two
+properties matter:
+
+- **It cannot un-write the file.** The edit already happened; `exit 2` feeds the
+  hint back to the agent as "fix this now". Prevention still belongs to CI and
+  pre-commit — this layer closes the feedback loop fast.
+- **It fails open.** Missing `jq`/`perl`/`markdownlint` → allow through, exactly
+  like `guard-bash.sh`.
+
+The shipped checks on edited `.md` files:
+
+1. **No emojis in documentation** (always on). Flags emoji/pictographs while
+   deliberately allowing arrows (`->` and U+2192), em-dash, and box-drawing that
+   docs use legitimately. Per-file opt-out: a line containing
+   `<!-- contract:allow-emoji -->`.
+2. **markdownlint** — runs only when the project ships a markdownlint config
+   (`.markdownlint.json` and friends). Without a config, default rules would flood
+   false positives, so the check stays dormant rather than noisy.
+
+Wire it in `.claude/settings.json` alongside the Level 0 hook:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          { "type": "command", "command": "bash .claude/hooks/verify-edit.sh" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Add project-specific post-edit checks at the bottom of `verify-edit.sh`, following
+the emoji check's structure.
 
 ## Pre-Commit Hooks
 

--- a/patterns/quick-reference.md
+++ b/patterns/quick-reference.md
@@ -2,7 +2,7 @@
 
 Scope: `[universal]` `[frequent]` `[situational]` `[rare]`
 Stack: `[node]` `[python]` `[macos]` `[github]` (omitted = all stacks)
-Enforcement: `[hook-enforced]` = blocked by PreToolUse hook.
+Enforcement: `[hook-enforced]` = blocked/flagged by a PreToolUse or PostToolUse hook.
 Skills: `[skill:name]` points to `.claude/skills/name/` for full examples.
 
 ## Shell & Tools
@@ -166,6 +166,8 @@ Skills: `[skill:name]` points to `.claude/skills/name/` for full examples.
 59. **Use `.claude/rules/` with `paths` frontmatter for conditional rules** `[frequent]` -- domain rules load only when Claude works with matching files (e.g., deployment rules on `.github/**`, test rules on `**/*.test.*`). Replaces `<important if>` blocks with infrastructure-level conditional loading.
 
 68. **Every fallback path must be observable** `[universal]` -- add ERROR-level logging when fallbacks activate, health endpoint coverage for degraded state, and alerting hooks. A silent fallback is a silent production bug.
+
+77. **No emojis in documentation** `[universal]` `[hook-enforced]` -- use text equivalents (PASS, `[x]`, `->`), not emoji/pictographs. Enforced post-edit by `verify-edit.sh` on `.md` files (arrows/dashes/box-drawing are allowed). Per-file opt-out: a line containing `<!-- contract:allow-emoji -->`.
 
 ## Agent Reports
 

--- a/templates/commands/pre-launch.md
+++ b/templates/commands/pre-launch.md
@@ -149,6 +149,11 @@ Rules:
 - Prefer systemic findings: one pattern covering 5 instances > five
   separate nitpicks.
 
+This contract is machine-checkable: `/remediate` runs
+`.claude/scripts/validate-findings.py` against the report before parsing and
+rejects any finding with a malformed Finding-ID, a missing required field, or
+no `file:line` ref. Emit findings in exactly this format.
+
 ### Cross-Domain Notes (optional)
 
 Findings touching another specialist's domain — noted briefly, referenced

--- a/templates/commands/remediate.md
+++ b/templates/commands/remediate.md
@@ -28,6 +28,19 @@ Gather context before making any changes.
    QA, UX). Section 14 (Before/After/Later) is the wave-ordering index.
    Section 15 (Open Questions) is NOT findings — skip it.
 
+   **Validate the report contract first** (deterministic gate, before any
+   parsing):
+
+   ```bash
+   python3 .claude/scripts/validate-findings.py <report-path>
+   ```
+
+   Exit 0 — findings satisfy the Output Contract; proceed. Non-zero — the
+   report has malformed findings (bad Finding-ID, missing required field, or
+   no `file:line`). **STOP** and report exactly which findings the validator
+   named. Do not parse a broken report: the consumer regex below would
+   silently drop the malformed ones, violating Rule #58 (100% coverage).
+
 2. **Extract EVERY finding** — all 5 severity tiers: launch-blocker,
    high, medium, low, strategic. No filtering by severity — Rule #58
    100% coverage.
@@ -36,6 +49,7 @@ Gather context before making any changes.
 
    - Findings are the `#### <Finding-ID> <Title>` blocks in §4-§11.
    - Finding ID regex: `(AR|FE|BE|PE|DO|SE|QA|UX)-(B|H|M|L|S)[0-9]+`
+     (machine-checked by `validate-findings.py` in step 1).
    - Each finding has structured fields (bold format:
      `**Severity:**`, `**Time horizon:**`, `**Evidence type:**`,
      `**Files:**`, `**What's happening:**`, `**Why it matters:**`,

--- a/templates/hooks/guard-bash.sh
+++ b/templates/hooks/guard-bash.sh
@@ -8,6 +8,10 @@
 # Input:    JSON on stdin: { "tool_name": "Bash", "tool_input": { "command": "..." } }
 # Output:   exit 0 = allow, exit 2 = block (stdout shown to agent as reason)
 #
+# Block messages use the corrective-hint convention (BLOCKED / WHY / FIX) via
+# emit_block — a block is a guided correction, not just a stop. See
+# methodology/ci-and-guardrails.md "Block messages are corrective hints".
+#
 # Add project-specific guards at the bottom of this file.
 
 # Intentionally no `set -e` — this script is fail-open by design.
@@ -15,6 +19,12 @@
 # execution falls through to exit 0 and the command is allowed.
 # A guard hook must never block legitimate work due to its own bugs.
 set -uo pipefail
+
+# emit_block <hook> <reason> <why> <fix> — print a corrective-hint block.
+# $4 (fix) may be multi-line; keep its own indentation.
+emit_block() {
+  printf 'BLOCKED by %s — %s\n\nWHY: %s\n\nFIX:\n%s\n' "$1" "$2" "$3" "$4"
+}
 
 # Require jq for JSON parsing — allow through if unavailable
 if ! command -v jq &>/dev/null; then
@@ -34,13 +44,10 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 # Agent edits files, then runs git pull --rebase without committing first.
 if [[ "$COMMAND" == *"git pull"* ]] && [[ "$COMMAND" == *"--rebase"* ]]; then
   if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
-    echo "BLOCKED by guard-bash.sh — Error #33: uncommitted changes"
-    echo ""
-    echo "git pull --rebase will fail with a dirty working tree."
-    echo "Commit or stash first, then pull:"
-    echo ""
-    echo "  git add <files> && git commit -m \"msg\""
-    echo "  git pull --rebase && git push"
+    emit_block "guard-bash.sh" "Error #33: uncommitted changes" \
+      "git pull --rebase fails with a dirty working tree." \
+      "  git add <files> && git commit -m \"msg\"
+  git pull --rebase && git push"
     exit 2
   fi
 fi
@@ -53,13 +60,10 @@ if [[ "$COMMAND" == *"git push"* ]]; then
   # Error #44: --tags pushes ALL local tags, not just the new one.
   # Old tags that already exist on remote cause a non-zero exit code.
   if [[ "$COMMAND" == *"--tags"* ]] && [[ "$COMMAND" != *"--follow-tags"* ]]; then
-    echo "BLOCKED by guard-bash.sh — Error #44: --tags pushes all local tags"
-    echo ""
-    echo "--tags pushes every tag, not just new ones. Old tags cause failures."
-    echo "Push specific tags or use --follow-tags:"
-    echo ""
-    echo "  git push origin main && git push origin v1.0.0"
-    echo "  git push origin main --follow-tags"
+    emit_block "guard-bash.sh" "Error #44: --tags pushes all local tags" \
+      "--tags pushes every tag, not just new ones; old tags cause failures." \
+      "  git push origin main && git push origin v1.0.0
+  git push origin main --follow-tags"
     exit 2
   fi
 
@@ -69,17 +73,11 @@ if [[ "$COMMAND" == *"git push"* ]]; then
   # Allows --follow-tags (release flow).
   if [[ "$COMMAND" =~ (^|[[:space:]])(main|master)($|[[:space:]]|:) ]] \
      && [[ "$COMMAND" != *"--follow-tags"* ]]; then
-    echo "BLOCKED by guard-bash.sh — Error #48: direct push to protected branch"
-    echo ""
-    echo "Pushing directly to main/master is a high-stakes action."
-    echo "If this is intentional (e.g., a release), ask the user first."
-    echo ""
-    echo "For normal development, push to a non-production branch, for example:"
-    echo "  git push origin develop                 # develop/main topology"
-    echo "  git push -u origin feature/my-change    # main-only or PR flow"
-    echo ""
-    echo "For releases with tags:"
-    echo "  git push origin main --follow-tags"
+    emit_block "guard-bash.sh" "Error #48: direct push to protected branch" \
+      "Pushing directly to main/master is a high-stakes action." \
+      "  git push origin develop                 # develop/main topology
+  git push -u origin feature/my-change    # main-only or PR flow
+  git push origin main --follow-tags      # releases with tags (ask first)"
     exit 2
   fi
 
@@ -90,8 +88,9 @@ fi
 
 # Example: block bare python3 (uncomment for Python/uv projects)
 # if [[ "$COMMAND" =~ ^python3?[[:space:]] ]] && [[ "$COMMAND" != *"uv run"* ]] && [[ "$COMMAND" != *"poetry run"* ]]; then
-#   echo "BLOCKED — use 'uv run python' instead of bare 'python3'"
-#   echo "System Python doesn't have project dependencies."
+#   emit_block "guard-bash.sh" "Rule #44: bare python3" \
+#     "System Python doesn't have project dependencies." \
+#     "  uv run python <args>"
 #   exit 2
 # fi
 

--- a/templates/hooks/verify-edit.sh
+++ b/templates/hooks/verify-edit.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# verify-edit.sh — PostToolUse hook for Write/Edit on markdown files.
+#
+# Post-action verification: a deterministic check that runs AFTER an edit lands
+# and surfaces violations back to the agent so it fixes them immediately, instead
+# of waiting for CI. Realizes "Level 1: Editor-time" from
+# methodology/ci-and-guardrails.md for the Claude Code harness.
+#
+# Location: .claude/hooks/verify-edit.sh (in projects)
+# Config:   .claude/settings.json → hooks.PostToolUse (matcher "Write|Edit")
+# Input:    JSON on stdin: { "tool_name": "...", "tool_input": { "file_path": "..." } }
+# Output:   exit 0 = ok, exit 2 = surface the corrective hint to the agent.
+#
+# NOTE: PostToolUse cannot prevent the write — the edit already landed. exit 2
+# feeds the hint to the agent as "fix this now". The hard gate stays CI/pre-commit.
+#
+# Checks:
+#   1. No emojis in docs (always on; per-file opt-out via <!-- contract:allow-emoji -->)
+#   2. markdownlint — ONLY when the project ships a markdownlint config (otherwise
+#      default rules flood false positives on repos that never opted into linting).
+
+# Fail-open by design — see guard-bash.sh. Any tooling gap → allow through.
+set -uo pipefail
+
+# emit_block <reason> <why> <fix> — corrective-hint convention (BLOCKED/WHY/FIX).
+emit_block() {
+  printf 'BLOCKED by verify-edit.sh — %s\n\nWHY: %s\n\nFIX:\n%s\n' "$1" "$2" "$3"
+}
+
+command -v jq &>/dev/null || exit 0
+
+read -r -d '' INPUT || true
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+# Only Write/Edit on markdown files.
+[[ "$TOOL" == "Write" || "$TOOL" == "Edit" ]] || exit 0
+[[ "$FILE" == *.md ]] || exit 0
+[[ -f "$FILE" ]] || exit 0
+
+
+# ─── Check 1: emoji in documentation ──────────────────────────────────────
+# Per-file opt-out for files that must show an emoji as a literal example.
+if ! grep -q 'contract:allow-emoji' "$FILE" 2>/dev/null && command -v perl &>/dev/null; then
+  # Ranges target true emoji/pictographs. Deliberately EXCLUDE arrows
+  # (U+2190-21FF, e.g. →), em-dash (U+2014), and box-drawing (U+2500-257F),
+  # all of which cc-rpi docs use legitimately.
+  HITS=$(perl -CSD -ne \
+    'while (/([\x{1F000}-\x{1FAFF}\x{2600}-\x{27BF}\x{2B00}-\x{2BFF}\x{FE0F}])/g) {
+       printf "    line %d: U+%04X\n", $., ord($1) }' "$FILE" 2>/dev/null)
+  if [[ -n "$HITS" ]]; then
+    emit_block "no emojis in documentation" \
+      "Project policy: docs use text equivalents (PASS, [x], ->), not emoji." \
+      "  Remove the emoji at:
+$HITS
+  (Only if a glyph is a required literal example, add a line containing
+  <!-- contract:allow-emoji --> to this file to skip this check.)"
+    exit 2
+  fi
+fi
+
+
+# ─── Check 2: markdownlint (config-gated) ─────────────────────────────────
+MDL_CONFIG=""
+for c in .markdownlint.json .markdownlint.jsonc .markdownlint.yaml .markdownlint.yml .markdownlintrc; do
+  [[ -f "$c" ]] && MDL_CONFIG="$c" && break
+done
+# Probe that markdownlint actually runs — otherwise a "tool not found" exit
+# would be misread as lint violations and falsely block. Fail-open if absent.
+if [[ -n "$MDL_CONFIG" ]] && command -v npx &>/dev/null \
+   && npx --no-install markdownlint --version &>/dev/null; then
+  if ! LINT=$(npx --no-install markdownlint "$FILE" 2>&1); then
+    NL=$'\n'
+    emit_block "markdownlint violations" \
+      "Lint errors fail CI; fix them at edit time, not at push." \
+      "    ${LINT//$NL/$NL    }"
+    exit 2
+  fi
+fi
+
+
+exit 0

--- a/templates/scripts/validate-findings.py
+++ b/templates/scripts/validate-findings.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""validate-findings.py — enforce the pre-launch Output Contract.
+
+The pre-launch report declares a finding format (Finding-ID grammar + required
+fields) that /remediate parses. Today that contract is prose: a malformed finding
+is silently dropped by the consumer regex. This validator makes the contract
+machine-checkable — it rejects a report whose findings violate the grammar, are
+missing required fields, or lack a file:line ref ("no refs = no finding").
+
+Usage:
+    validate-findings.py <report.md>     # exit 0 if valid, 1 if violations
+    validate-findings.py --self-test     # run bundled fixtures, exit 0/1
+
+Stdlib only. Spec: pre-launch.md "Output Contract", remediate.md "Parser contract".
+"""
+
+import argparse
+import os
+import re
+import sys
+
+# Strict Finding-ID grammar (must match the /remediate consumer regex).
+ID_VALID = re.compile(r"^(AR|FE|BE|PE|DO|SE|QA|UX)-(B|H|M|L|S)[0-9]+$")
+# Loose "looks like someone tried to write a Finding-ID" — used to detect
+# malformed IDs (lowercase, wrong severity letter, etc.) that the consumer
+# would silently drop.
+ID_SHAPED = re.compile(r"^[A-Za-z]{2}-[A-Za-z]?[0-9]+")
+# A file:line reference, e.g. src/app.ts:42 or path/x.py:110-130.
+FILELINE = re.compile(r"\S+:[0-9]+")
+
+REQUIRED_FIELDS = [
+    "Severity",
+    "Time horizon",
+    "Evidence type",
+    "Files",
+    "What's happening",
+    "Why it matters",
+    "Recommendation",
+    "Expected impact",
+    "Effort estimate",
+]
+
+
+class Block:
+    def __init__(self, heading_line):
+        self.heading = heading_line.rstrip("\n")
+        self.body_lines = []
+
+    @property
+    def first_token(self):
+        # "#### SE-B1 Title" -> "SE-B1"
+        parts = self.heading[4:].strip().split()
+        return parts[0] if parts else ""
+
+    @property
+    def body(self):
+        return "\n".join(self.body_lines)
+
+    def field_value(self, name):
+        # Return the text after "**Name:**" on its line, or None.
+        m = re.search(
+            r"\*\*" + re.escape(name) + r":\*\*(.*)",
+            self.body,
+        )
+        return m.group(1).strip() if m else None
+
+
+def parse_blocks(text):
+    """Yield every #### block in the document (heading + following lines up to
+    the next #### or ## heading)."""
+    blocks = []
+    current = None
+    for line in text.splitlines(keepends=True):
+        if line.startswith("#### "):
+            current = Block(line)
+            blocks.append(current)
+        elif line.startswith("## ") or line.startswith("# "):
+            current = None  # left the block
+        elif current is not None:
+            current.body_lines.append(line.rstrip("\n"))
+    return blocks
+
+
+def is_finding_candidate(block):
+    """A #### block we should hold to the contract: it either attempts a
+    Finding-ID or carries finding fields (so a dropped one is a real loss)."""
+    return bool(ID_SHAPED.match(block.first_token)) or (
+        "**Severity:**" in block.body
+    )
+
+
+def validate_text(text):
+    """Return a list of (finding-label, reason) violations."""
+    errors = []
+    for block in parse_blocks(text):
+        if not is_finding_candidate(block):
+            continue
+        label = block.first_token or block.heading.strip()
+        if not ID_VALID.match(block.first_token):
+            errors.append(
+                (label, "invalid or missing Finding-ID "
+                        "(want <AR|FE|BE|PE|DO|SE|QA|UX>-<B|H|M|L|S><n>)")
+            )
+        for field in REQUIRED_FIELDS:
+            if f"**{field}:**" not in block.body:
+                errors.append((label, f"missing required field: {field}"))
+        files = block.field_value("Files")
+        if files is not None and not FILELINE.search(files):
+            errors.append(
+                (label, "no file:line ref in Files (no refs = no finding)")
+            )
+    return errors
+
+
+def validate_file(path):
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        return validate_text(fh.read())
+
+
+# --- bundled fixtures for --self-test -------------------------------------
+
+VALID_FIXTURE = """## 5. Backend
+
+#### BE-H1 N+1 query in the orders endpoint
+- **Severity:** high
+- **Time horizon:** Before launch
+- **Evidence type:** [evidence]
+- **Files:** src/orders/api.ts:42, src/orders/repo.ts:110-130
+- **What's happening:** the list endpoint issues one query per row.
+- **Why it matters:** p95 latency scales with result size.
+- **Recommendation:** batch the lookups with a single join.
+- **Expected impact:** flat latency under load.
+- **Effort estimate:** M
+
+## 6. Performance
+
+### Domain Model
+Plain prose, not a finding.
+"""
+
+INVALID_FIXTURE = """## 5. Backend
+
+#### be-h1 lowercase id is malformed
+- **Severity:** high
+- **Time horizon:** Before launch
+- **Evidence type:** [evidence]
+- **Files:** src/orders/api.ts:42
+- **What's happening:** x
+- **Why it matters:** y
+- **Recommendation:** z
+- **Expected impact:** w
+- **Effort estimate:** M
+
+#### SE-B1 missing fields and no file:line
+- **Severity:** launch-blocker
+- **Files:** src/auth/login.ts
+- **Why it matters:** y
+"""
+
+
+def self_test():
+    ok = True
+    valid_errs = validate_text(VALID_FIXTURE)
+    if valid_errs:
+        ok = False
+        print("SELF-TEST FAIL: valid fixture reported errors:")
+        for label, reason in valid_errs:
+            print(f"  {label}: {reason}")
+    else:
+        print("SELF-TEST PASS: valid fixture clean")
+
+    invalid_errs = validate_text(INVALID_FIXTURE)
+    # Expect: bad ID on be-h1, plus SE-B1 missing several fields + no file:line.
+    labels = {label for label, _ in invalid_errs}
+    expect_bad_id = any(
+        "invalid or missing Finding-ID" in r for _, r in invalid_errs
+    )
+    expect_missing = any("missing required field" in r for _, r in invalid_errs)
+    expect_noref = any("no file:line ref" in r for _, r in invalid_errs)
+    if invalid_errs and expect_bad_id and expect_missing and expect_noref:
+        print(f"SELF-TEST PASS: invalid fixture flagged "
+              f"{len(invalid_errs)} violations across {sorted(labels)}")
+    else:
+        ok = False
+        print("SELF-TEST FAIL: invalid fixture not fully flagged:")
+        for label, reason in invalid_errs:
+            print(f"  {label}: {reason}")
+    return ok
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", nargs="?", help="path to the pre-launch report")
+    parser.add_argument("--self-test", action="store_true",
+                        help="run bundled fixtures and exit")
+    args = parser.parse_args()
+
+    if args.self_test:
+        sys.exit(0 if self_test() else 1)
+
+    if not args.report:
+        parser.error("a report path is required (or use --self-test)")
+    if not os.path.isfile(args.report):
+        print(f"ERROR: report not found: {args.report}", file=sys.stderr)
+        sys.exit(2)
+
+    errors = validate_file(args.report)
+    if errors:
+        print(f"CONTRACT VIOLATION: {len(errors)} issue(s) in {args.report}",
+              file=sys.stderr)
+        for label, reason in errors:
+            print(f"  {label}: {reason}", file=sys.stderr)
+        sys.exit(1)
+    print(f"OK: report findings satisfy the Output Contract ({args.report})")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/settings.json.template
+++ b/templates/settings.json.template
@@ -13,6 +13,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/verify-edit.sh"
+          }
+        ]
+      }
     ]
   },
   "permissions": {


### PR DESCRIPTION
## Summary

Adds a targeted **contract layer** that converts the mechanically-detectable subset of cc-rpi's docs-as-contract conventions from advisory prose into deterministic guarantees. Inspired by `contract-driven-llm-agent` (idea source only — no SQL/ontology machinery ported).

Plan: `docs/plans/2026-06-22-contract-layer.md` · 4 phases · `/validate`-PASSED 2026-06-23.

## What landed

- **Phase 1 — corrective-hint convention.** Shared `emit_block` helper + `BLOCKED / WHY / FIX` format across hooks (`guard-bash.sh`). A block is now a guided correction, not just a stop.
- **Phase 2 — PostToolUse `verify-edit.sh`.** Emoji gate (excludes arrows/em-dash/box-drawing) + config-gated markdownlint on edited `.md`; fail-open; wired into both `settings.json` files. Realizes the previously-aspirational "Level 1: Editor-time" tier.
- **Phase 3 — `validate-findings.py`.** Stdlib Finding-ID validator (exit 0/1/2, `--self-test`), wired as a Step-1 gate in `/remediate`, noted in `/pre-launch`.
- **Phase 4 — docs sweep.** Rule #77 (76 -> 77) across CHANGELOG / GUIDE / CLAUDE.md / AGENTS.md / quick-reference; `validate.yml` extended to shellcheck the new hook and run the validator self-test (the contract layer verifies itself in CI).

## Deviations from the plan (all sound, all documented)

1. **guard-bash twins not byte-identical** — divergence confined to the Error #48 block only: cc-rpi comments it out (`main` is its long-lived branch), the template keeps it active. Both use `emit_block`.
2. **markdownlint is config-gated**, not always-on — this repo ships no markdownlint config and the corpus fails default rules, so the hook only runs markdownlint when a config is present (emoji-only on cc-rpi itself).
3. **`verify-edit.sh` outputs stdout + `exit 2`** (matching `guard-bash.sh` and `ci-and-guardrails.md`), not the JSON `decision:block` the plan sketched.

## Validation

All automated checks green: `bash -n` + shellcheck on all hooks, `py_compile` + `--self-test` on the validator, byte-identical template twins (except the intentional #48 divergence), JSON/YAML validity, and behavioral tests for every hook path (emoji block, clean pass, box-drawing not flagged, opt-out, fail-open, validator 0/1/2).

## Before merge — two live-session manual checks remain

- [ ] Edit a `.md` to add an emoji in a live session → agent receives the hint and removes it (loop closes).
- [ ] Run `/remediate` against a deliberately malformed report → Step-1 gate rejects it and names the offender.

New methodology content (Rule #77 + a new enforcement tier) → warrants a `/release` version bump after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)