### PR TITLE
feat(metrics): measure contract-layer impact via hook telemetry

### DIFF
--- a/.claude/hooks/guard-bash.sh
+++ b/.claude/hooks/guard-bash.sh
@@ -26,6 +26,22 @@ emit_block() {
   printf 'BLOCKED by %s — %s\n\nWHY: %s\n\nFIX:\n%s\n' "$1" "$2" "$3" "$4"
 }
 
+# log_event <decision> <rule> — append-only contract-metrics telemetry. One JSONL
+# row per evaluated git command so guard adherence can be measured over time (see
+# templates/scripts/contract-metrics.py). Fail-open; NEVER logs the command text
+# (it may contain tokens) — only the matched rule and decision.
+log_event() {
+  {
+    local dir="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/metrics"
+    mkdir -p "$dir" 2>/dev/null || return 0
+    local ts; ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || return 0
+    jq -cn --arg ts "$ts" --arg sid "${SESSION_ID:-}" --arg hook "guard-bash" \
+      --arg dec "$1" --arg rule "$2" --arg file "" \
+      '{ts:$ts,session_id:$sid,hook:$hook,decision:$dec,rule:$rule,file:$file}' \
+      >> "$dir/contract-events.jsonl" 2>/dev/null
+  } || true
+}
+
 # Require jq for JSON parsing — allow through if unavailable
 if ! command -v jq &>/dev/null; then
   exit 0
@@ -33,6 +49,7 @@ fi
 
 read -r -d '' INPUT || true
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
 [[ -z "$COMMAND" ]] && exit 0
 
 # Fast path: skip all guards for non-git commands (~90% of invocations)
@@ -48,6 +65,7 @@ if [[ "$COMMAND" == *"git pull"* ]] && [[ "$COMMAND" == *"--rebase"* ]]; then
       "git pull --rebase fails with a dirty working tree." \
       "  git add <files> && git commit -m \"msg\"
   git pull --rebase && git push"
+    log_event block error-33
     exit 2
   fi
 fi
@@ -64,6 +82,7 @@ if [[ "$COMMAND" == *"git push"* ]]; then
       "--tags pushes every tag, not just new ones; old tags cause failures." \
       "  git push origin main && git push origin v1.0.0
   git push origin main --follow-tags"
+    log_event block error-44
     exit 2
   fi
 
@@ -97,4 +116,6 @@ fi
 # fi
 
 
+# Reached only by git commands that passed every guard (non-git exits earlier).
+log_event allow none
 exit 0

--- a/.claude/hooks/verify-edit.sh
+++ b/.claude/hooks/verify-edit.sh
@@ -27,11 +27,28 @@ emit_block() {
   printf 'BLOCKED by verify-edit.sh — %s\n\nWHY: %s\n\nFIX:\n%s\n' "$1" "$2" "$3"
 }
 
+# log_event <decision> <rule> <file> — append-only contract-metrics telemetry.
+# One JSONL row per evaluated edit so the contract layer's impact can be measured
+# over time (see templates/scripts/contract-metrics.py). Fail-open: any error here
+# is swallowed — telemetry must never break a hook. Never logs file contents.
+log_event() {
+  {
+    local dir="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/metrics"
+    mkdir -p "$dir" 2>/dev/null || return 0
+    local ts; ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || return 0
+    jq -cn --arg ts "$ts" --arg sid "${SESSION_ID:-}" --arg hook "verify-edit" \
+      --arg dec "$1" --arg rule "$2" --arg file "${3:-}" \
+      '{ts:$ts,session_id:$sid,hook:$hook,decision:$dec,rule:$rule,file:$file}' \
+      >> "$dir/contract-events.jsonl" 2>/dev/null
+  } || true
+}
+
 command -v jq &>/dev/null || exit 0
 
 read -r -d '' INPUT || true
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
 
 # Only Write/Edit on markdown files.
 [[ "$TOOL" == "Write" || "$TOOL" == "Edit" ]] || exit 0
@@ -55,6 +72,7 @@ if ! grep -q 'contract:allow-emoji' "$FILE" 2>/dev/null && command -v perl &>/de
 $HITS
   (Only if a glyph is a required literal example, add a line containing
   <!-- contract:allow-emoji --> to this file to skip this check.)"
+    log_event block emoji "$FILE"
     exit 2
   fi
 fi
@@ -74,9 +92,11 @@ if [[ -n "$MDL_CONFIG" ]] && command -v npx &>/dev/null \
     emit_block "markdownlint violations" \
       "Lint errors fail CI; fix them at edit time, not at push." \
       "    ${LINT//$NL/$NL    }"
+    log_event block markdownlint "$FILE"
     exit 2
   fi
 fi
 
 
+log_event allow none "$FILE"
 exit 0

--- a/.claude/scripts/contract-metrics.py
+++ b/.claude/scripts/contract-metrics.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""contract-metrics.py — aggregate contract-layer hook telemetry into a report.
+
+Reads the append-only JSONL audit log written by the contract-layer hooks
+(`guard-bash.sh`, `verify-edit.sh`) at `.claude/metrics/contract-events.jsonl`
+and reports whether the layer is doing anything measurable:
+
+  - block counts and block rate, per hook and per rule
+  - verify-edit SELF-CORRECTION rate: a block on a file followed by a later clean
+    edit of that same file in the same session = the corrective-hint loop closed
+  - week-over-week trend (blocks per 100 events) to spot agents internalizing
+    rules over time (declining block rate at stable volume)
+
+Stdlib only. Read-only. Best-effort: malformed log lines are skipped, never fatal.
+
+Usage:
+  contract-metrics.py [path]          # report on a log (default .claude/metrics/...)
+  contract-metrics.py --json [path]   # machine-readable metrics
+  contract-metrics.py --self-test     # prove the math on a synthetic fixture
+
+Exit codes: 0 = ok (including "no data yet"); 1 = self-test failed; 2 = bad usage.
+"""
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime
+
+DEFAULT_LOG = ".claude/metrics/contract-events.jsonl"
+
+
+def iso_week(ts):
+    """Return 'YYYY-Www' for an ISO-8601 'Z' timestamp, or None if unparseable."""
+    try:
+        dt = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ")
+    except (ValueError, TypeError):
+        return None
+    y, w, _ = dt.isocalendar()
+    return f"{y}-W{w:02d}"
+
+
+def parse_events(lines):
+    """Parse JSONL lines into event dicts, skipping blanks and malformed rows."""
+    events = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(obj, dict):
+            events.append(obj)
+    return events
+
+
+def compute(events):
+    """Reduce a list of event dicts to the metrics the report renders."""
+    m = {
+        "total": len(events),
+        "by_hook": Counter(),
+        "by_hook_block": Counter(),
+        "by_rule_block": Counter(),
+        "files_block": Counter(),
+        "weekly": defaultdict(lambda: {"events": 0, "blocks": 0}),
+        "first_ts": None,
+        "last_ts": None,
+    }
+    # (session_id, file) -> [(ts, decision), ...] for verify-edit self-correction
+    groups = defaultdict(list)
+
+    for e in events:
+        hook = e.get("hook", "?")
+        decision = e.get("decision", "?")
+        rule = e.get("rule", "none")
+        ts = e.get("ts", "") or ""
+        file = e.get("file", "") or ""
+
+        m["by_hook"][hook] += 1
+        if ts:
+            if m["first_ts"] is None or ts < m["first_ts"]:
+                m["first_ts"] = ts
+            if m["last_ts"] is None or ts > m["last_ts"]:
+                m["last_ts"] = ts
+        wk = iso_week(ts)
+        if wk:
+            m["weekly"][wk]["events"] += 1
+
+        if decision == "block":
+            m["by_hook_block"][hook] += 1
+            m["by_rule_block"][f"{hook}:{rule}"] += 1
+            if wk:
+                m["weekly"][wk]["blocks"] += 1
+            if hook == "verify-edit" and file:
+                m["files_block"][file] += 1
+
+        if hook == "verify-edit" and file:
+            groups[(e.get("session_id", "") or "", file)].append((ts, decision))
+
+    # Self-correction: a block is "corrected" if a later clean allow lands on the
+    # same file in the same session (the agent took the hint and fixed it).
+    sc_blocks = sc_corrected = 0
+    for evs in groups.values():
+        evs.sort(key=lambda x: x[0])
+        for i, (_, decision) in enumerate(evs):
+            if decision == "block":
+                sc_blocks += 1
+                if any(d == "allow" for (_, d) in evs[i + 1:]):
+                    sc_corrected += 1
+    m["sc_blocks"] = sc_blocks
+    m["sc_corrected"] = sc_corrected
+    return m
+
+
+def _pct(num, den):
+    return (100.0 * num / den) if den else 0.0
+
+
+def render(m):
+    """Render the metrics dict as a human-readable markdown report."""
+    out = []
+    out.append("# Contract Layer Metrics")
+    if not m["total"]:
+        out.append("")
+        out.append("No events logged yet. The hooks write one row per evaluated")
+        out.append("edit/command once projects start using the contract layer.")
+        return "\n".join(out) + "\n"
+
+    span = ""
+    if m["first_ts"] and m["last_ts"]:
+        span = f" | {m['first_ts'][:10]} .. {m['last_ts'][:10]}"
+    out.append(f"> {m['total']} events{span}")
+    out.append("")
+
+    out.append("## Blocks by hook")
+    out.append("")
+    out.append("| Hook | Events | Blocks | Block rate |")
+    out.append("|------|--------|--------|------------|")
+    for hook in sorted(m["by_hook"]):
+        ev = m["by_hook"][hook]
+        bl = m["by_hook_block"][hook]
+        out.append(f"| {hook} | {ev} | {bl} | {_pct(bl, ev):.1f}% |")
+    out.append("")
+
+    out.append("## Blocks by rule")
+    out.append("")
+    out.append("| Hook:Rule | Blocks |")
+    out.append("|-----------|--------|")
+    for rule, n in m["by_rule_block"].most_common():
+        out.append(f"| {rule} | {n} |")
+    if not m["by_rule_block"]:
+        out.append("| (none) | 0 |")
+    out.append("")
+
+    out.append("## verify-edit self-correction")
+    out.append("")
+    out.append("Did the agent fix the file after a block (same file, same session)?")
+    out.append("")
+    rate = _pct(m["sc_corrected"], m["sc_blocks"])
+    out.append(f"- Blocks: {m['sc_blocks']}")
+    out.append(f"- Corrected by a later clean edit: {m['sc_corrected']}")
+    out.append(f"- **Self-correction rate: {rate:.1f}%**")
+    out.append("")
+
+    if m["files_block"]:
+        out.append("## Top files by verify-edit blocks")
+        out.append("")
+        for file, n in m["files_block"].most_common(10):
+            out.append(f"- {file}: {n}")
+        out.append("")
+
+    out.append("## Weekly trend (blocks per 100 events)")
+    out.append("")
+    out.append("Declining rate at stable volume = agents internalizing the rules.")
+    out.append("")
+    out.append("| Week | Events | Blocks | Blocks/100 |")
+    out.append("|------|--------|--------|------------|")
+    for wk in sorted(m["weekly"]):
+        ev = m["weekly"][wk]["events"]
+        bl = m["weekly"][wk]["blocks"]
+        out.append(f"| {wk} | {ev} | {bl} | {_pct(bl, ev):.1f} |")
+    out.append("")
+    return "\n".join(out) + "\n"
+
+
+def metrics_to_json(m):
+    """Flatten the metrics dict to plain JSON-serializable types."""
+    return {
+        "total": m["total"],
+        "by_hook": dict(m["by_hook"]),
+        "by_hook_block": dict(m["by_hook_block"]),
+        "by_rule_block": dict(m["by_rule_block"]),
+        "files_block": dict(m["files_block"]),
+        "self_correction": {
+            "blocks": m["sc_blocks"],
+            "corrected": m["sc_corrected"],
+            "rate_pct": round(_pct(m["sc_corrected"], m["sc_blocks"]), 1),
+        },
+        "weekly": {wk: dict(v) for wk, v in m["weekly"].items()},
+        "first_ts": m["first_ts"],
+        "last_ts": m["last_ts"],
+    }
+
+
+SELF_TEST_EVENTS = [
+    {"ts": "2026-06-01T10:00:00Z", "session_id": "A", "hook": "verify-edit",
+     "decision": "block", "rule": "emoji", "file": "x.md"},
+    {"ts": "2026-06-01T10:05:00Z", "session_id": "A", "hook": "verify-edit",
+     "decision": "allow", "rule": "none", "file": "x.md"},
+    {"ts": "2026-06-01T10:10:00Z", "session_id": "A", "hook": "verify-edit",
+     "decision": "block", "rule": "emoji", "file": "y.md"},
+    {"ts": "2026-06-02T11:00:00Z", "session_id": "A", "hook": "guard-bash",
+     "decision": "block", "rule": "error-44", "file": ""},
+    {"ts": "2026-06-02T11:01:00Z", "session_id": "A", "hook": "guard-bash",
+     "decision": "allow", "rule": "none", "file": ""},
+    {"ts": "2026-06-09T09:00:00Z", "session_id": "B", "hook": "verify-edit",
+     "decision": "allow", "rule": "none", "file": "z.md"},
+]
+
+
+def self_test():
+    m = compute(SELF_TEST_EVENTS)
+    checks = [
+        ("total", m["total"], 6),
+        ("verify-edit events", m["by_hook"]["verify-edit"], 4),
+        ("guard-bash events", m["by_hook"]["guard-bash"], 2),
+        ("verify-edit blocks", m["by_hook_block"]["verify-edit"], 2),
+        ("guard-bash blocks", m["by_hook_block"]["guard-bash"], 1),
+        ("emoji blocks", m["by_rule_block"]["verify-edit:emoji"], 2),
+        ("sc_blocks", m["sc_blocks"], 2),
+        ("sc_corrected", m["sc_corrected"], 1),
+        # 06-01 and 06-02 are the same ISO week (W23); 06-09 is W24 -> 2 weeks.
+        ("weeks tracked", len(m["weekly"]), 2),
+    ]
+    ok = True
+    for name, got, want in checks:
+        if got != want:
+            ok = False
+            print(f"SELF-TEST FAIL: {name} = {got}, expected {want}")
+    if ok:
+        # render must not raise on real data
+        render(m)
+        print("SELF-TEST PASS: 9 checks across 2 sessions/weeks")
+        return 0
+    return 1
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Aggregate contract-layer hook telemetry.")
+    ap.add_argument("path", nargs="?", default=DEFAULT_LOG,
+                    help=f"JSONL event log (default {DEFAULT_LOG})")
+    ap.add_argument("--json", action="store_true", help="emit JSON instead of a report")
+    ap.add_argument("--self-test", action="store_true", help="run the built-in fixture test")
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    try:
+        with open(args.path, encoding="utf-8") as fh:
+            events = parse_events(fh)
+    except FileNotFoundError:
+        # No log yet is a normal early state, not an error.
+        if args.json:
+            print(json.dumps({"total": 0, "note": "no log file yet"}))
+        else:
+            print(f"# Contract Layer Metrics\n\nNo log at {args.path} yet.")
+        return 0
+
+    m = compute(events)
+    if args.json:
+        print(json.dumps(metrics_to_json(m), indent=2))
+    else:
+        sys.stdout.write(render(m))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -55,6 +55,7 @@ jobs:
         run: |
           shellcheck --severity=warning \
             templates/scripts/cc-rpi-update-agent.sh \
+            templates/scripts/agents/contract-metrics-agent.sh \
             templates/hooks/guard-bash.sh \
             templates/hooks/verify-edit.sh
 
@@ -63,6 +64,12 @@ jobs:
         run: |
           python3 -m py_compile templates/scripts/validate-findings.py
           python3 templates/scripts/validate-findings.py --self-test
+
+      # --- Contract-metrics aggregator self-test ---
+      - name: Validate contract-metrics aggregator
+        run: |
+          python3 -m py_compile templates/scripts/contract-metrics.py
+          python3 templates/scripts/contract-metrics.py --self-test
 
       # --- JSON syntax validation ---
       - name: Validate JSON files

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 .claude/tasks/
 .claude/debug/
 
+# Contract-layer telemetry (local audit log; the report snapshot lives in docs/agents/)
+.claude/metrics/
+
 # Internal working docs (research, plans)
 docs/research/
 docs/plans/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,3 +75,9 @@ When the user invokes a slash-style command:
   pre-launch report before parsing in a `/remediate`-style flow, and STOP if
   it exits non-zero. When a guard blocks, phrase the reason as
   `BLOCKED / WHY / FIX` with a runnable fix.
+- **Contract metrics.** The hook telemetry log is written by the Claude-Code
+  hooks, so Codex sessions won't populate it. But `contract-metrics.py` is
+  portable stdlib: if a Codex harness writes the same JSONL shape
+  (`{ts, session_id, hook, decision, rule, file}`) to
+  `.claude/metrics/contract-events.jsonl`, the aggregator and the weekly
+  `contract-metrics-agent.sh` snapshot work unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Contract-layer metrics (impact measurement).** The `guard-bash.sh` and
+  `verify-edit.sh` hooks now append one fail-open JSONL row per evaluated
+  command/edit to `.claude/metrics/contract-events.jsonl` (decision, rule, file,
+  session — never command text or file contents). `templates/scripts/contract-metrics.py`
+  aggregates the log into block rates per hook/rule, a verify-edit **self-correction
+  rate** (block followed by a clean re-edit of the same file in the same session),
+  and a week-over-week trend. A deterministic `contract-metrics-agent.sh`
+  (weekly, no Claude CLI / no cost) snapshots the report to
+  `docs/agents/contract-metrics-report.md`. Lets you evaluate months from now
+  whether the contract layer actually changed agent behavior, instead of trusting
+  blindly. Raw log gitignored (`.claude/metrics/`); report follows Rule #70.
+
 ## [1.22.0] - 2026-06-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,7 @@ Go directly to these paths -- never search the codebase for them.
 | Active commands | `.claude/commands/` | This repo's own commands |
 | Hooks | `templates/hooks/guard-bash.sh` (PreToolUse), `templates/hooks/verify-edit.sh` (PostToolUse) | Templates; `.claude/hooks/` active |
 | Contract validator | `templates/scripts/validate-findings.py` | Enforces pre-launch/remediate Finding-ID contract; `.claude/scripts/` active |
+| Contract metrics | `templates/scripts/contract-metrics.py` | Aggregates hook telemetry (`.claude/metrics/contract-events.jsonl`) into block/self-correction rates; weekly snapshot via `scripts/agents/contract-metrics-agent.sh` |
 | Research | `docs/research/YYYY-MM-DD-*.md` | RPI research about cc-rpi |
 | Plans | `docs/plans/YYYY-MM-DD-*.md` | RPI plans for cc-rpi |
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -369,7 +369,8 @@ your-project/
 ├── .claude/
 │   ├── settings.json            # Tool permissions, Agent Teams, hooks
 │   ├── hooks/                   # guard-bash.sh (PreToolUse), verify-edit.sh (PostToolUse)
-│   ├── scripts/                 # validate-findings.py (pre-launch/remediate contract)
+│   ├── scripts/                 # validate-findings.py (contract), contract-metrics.py (hook telemetry)
+│   ├── metrics/                 # contract-events.jsonl (gitignored hook audit log)
 │   ├── commands/                # Slash commands (user-invoked workflows)
 │   │   ├── research.md          # /research
 │   │   ├── plan.md              # /plan

--- a/methodology/ci-and-guardrails.md
+++ b/methodology/ci-and-guardrails.md
@@ -161,6 +161,31 @@ Wire it in `.claude/settings.json` alongside the Level 0 hook:
 Add project-specific post-edit checks at the bottom of `verify-edit.sh`, following
 the emoji check's structure.
 
+### Measuring whether enforcement works
+
+Enforcement you can't measure is enforcement you trust blindly. Both hooks append
+one **fail-open** JSONL row per evaluated command/edit to
+`.claude/metrics/contract-events.jsonl` — `{ts, session_id, hook, decision, rule,
+file}`. They never log command text or file contents (guard-bash sees commands
+that may carry tokens), and any logging error is swallowed so telemetry can never
+break a hook.
+
+`templates/scripts/contract-metrics.py` aggregates that log into:
+
+- **block rate** per hook and per rule (how much the layer is catching),
+- **self-correction rate** — a verify-edit block followed by a clean re-edit of the
+  same file in the same session, i.e. the corrective-hint loop actually closing,
+- a **week-over-week trend** (blocks per 100 events): a declining rate at stable
+  volume is the signal that agents are internalizing the rules, not just being
+  caught by them.
+
+The raw log is gitignored; a weekly deterministic agent
+(`contract-metrics-agent.sh`, no Claude CLI) snapshots the report to
+`docs/agents/contract-metrics-report.md` for review over time. Because the feature
+is new, the day it ships is a clean `t=0` — no pre-feature baseline to reconstruct.
+Read the self-correction rate as the cleanest signal: it is within-session, so it
+sidesteps confounds (model updates, changing project mix) that muddy the raw trend.
+
 ## Pre-Commit Hooks
 
 Pre-commit hooks run automatically before every commit and reject the commit if any check fails.

--- a/methodology/scheduled-agents.md
+++ b/methodology/scheduled-agents.md
@@ -196,6 +196,7 @@ launchd provides a minimal execution environment that breaks Claude CLI in four 
 | **Performance check** | Weekly | Bundle sizes, build times, regression detection |
 | **Documentation sync** | Weekly | Stale docs, undocumented public APIs, broken links |
 | **Cost report** | Weekly | AI spend per workflow and per outcome, tier-adherence drift (see [cost-monitoring.md](cost-monitoring.md)) |
+| **Contract metrics** | Weekly | Block rates and verify-edit self-correction rate from the contract-layer hook log; deterministic (no Claude CLI). See [ci-and-guardrails.md](ci-and-guardrails.md) |
 
 ## Concrete Agent Prompts
 

--- a/templates/hooks/guard-bash.sh
+++ b/templates/hooks/guard-bash.sh
@@ -26,6 +26,22 @@ emit_block() {
   printf 'BLOCKED by %s — %s\n\nWHY: %s\n\nFIX:\n%s\n' "$1" "$2" "$3" "$4"
 }
 
+# log_event <decision> <rule> — append-only contract-metrics telemetry. One JSONL
+# row per evaluated git command so guard adherence can be measured over time (see
+# templates/scripts/contract-metrics.py). Fail-open; NEVER logs the command text
+# (it may contain tokens) — only the matched rule and decision.
+log_event() {
+  {
+    local dir="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/metrics"
+    mkdir -p "$dir" 2>/dev/null || return 0
+    local ts; ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || return 0
+    jq -cn --arg ts "$ts" --arg sid "${SESSION_ID:-}" --arg hook "guard-bash" \
+      --arg dec "$1" --arg rule "$2" --arg file "" \
+      '{ts:$ts,session_id:$sid,hook:$hook,decision:$dec,rule:$rule,file:$file}' \
+      >> "$dir/contract-events.jsonl" 2>/dev/null
+  } || true
+}
+
 # Require jq for JSON parsing — allow through if unavailable
 if ! command -v jq &>/dev/null; then
   exit 0
@@ -33,6 +49,7 @@ fi
 
 read -r -d '' INPUT || true
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
 [[ -z "$COMMAND" ]] && exit 0
 
 # Fast path: skip all guards for non-git commands (~90% of invocations)
@@ -48,6 +65,7 @@ if [[ "$COMMAND" == *"git pull"* ]] && [[ "$COMMAND" == *"--rebase"* ]]; then
       "git pull --rebase fails with a dirty working tree." \
       "  git add <files> && git commit -m \"msg\"
   git pull --rebase && git push"
+    log_event block error-33
     exit 2
   fi
 fi
@@ -64,6 +82,7 @@ if [[ "$COMMAND" == *"git push"* ]]; then
       "--tags pushes every tag, not just new ones; old tags cause failures." \
       "  git push origin main && git push origin v1.0.0
   git push origin main --follow-tags"
+    log_event block error-44
     exit 2
   fi
 
@@ -78,6 +97,7 @@ if [[ "$COMMAND" == *"git push"* ]]; then
       "  git push origin develop                 # develop/main topology
   git push -u origin feature/my-change    # main-only or PR flow
   git push origin main --follow-tags      # releases with tags (ask first)"
+    log_event block error-48
     exit 2
   fi
 
@@ -95,4 +115,6 @@ fi
 # fi
 
 
+# Reached only by git commands that passed every guard (non-git exits earlier).
+log_event allow none
 exit 0

--- a/templates/hooks/verify-edit.sh
+++ b/templates/hooks/verify-edit.sh
@@ -27,11 +27,28 @@ emit_block() {
   printf 'BLOCKED by verify-edit.sh — %s\n\nWHY: %s\n\nFIX:\n%s\n' "$1" "$2" "$3"
 }
 
+# log_event <decision> <rule> <file> — append-only contract-metrics telemetry.
+# One JSONL row per evaluated edit so the contract layer's impact can be measured
+# over time (see templates/scripts/contract-metrics.py). Fail-open: any error here
+# is swallowed — telemetry must never break a hook. Never logs file contents.
+log_event() {
+  {
+    local dir="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/metrics"
+    mkdir -p "$dir" 2>/dev/null || return 0
+    local ts; ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || return 0
+    jq -cn --arg ts "$ts" --arg sid "${SESSION_ID:-}" --arg hook "verify-edit" \
+      --arg dec "$1" --arg rule "$2" --arg file "${3:-}" \
+      '{ts:$ts,session_id:$sid,hook:$hook,decision:$dec,rule:$rule,file:$file}' \
+      >> "$dir/contract-events.jsonl" 2>/dev/null
+  } || true
+}
+
 command -v jq &>/dev/null || exit 0
 
 read -r -d '' INPUT || true
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
 
 # Only Write/Edit on markdown files.
 [[ "$TOOL" == "Write" || "$TOOL" == "Edit" ]] || exit 0
@@ -55,6 +72,7 @@ if ! grep -q 'contract:allow-emoji' "$FILE" 2>/dev/null && command -v perl &>/de
 $HITS
   (Only if a glyph is a required literal example, add a line containing
   <!-- contract:allow-emoji --> to this file to skip this check.)"
+    log_event block emoji "$FILE"
     exit 2
   fi
 fi
@@ -74,9 +92,11 @@ if [[ -n "$MDL_CONFIG" ]] && command -v npx &>/dev/null \
     emit_block "markdownlint violations" \
       "Lint errors fail CI; fix them at edit time, not at push." \
       "    ${LINT//$NL/$NL    }"
+    log_event block markdownlint "$FILE"
     exit 2
   fi
 fi
 
 
+log_event allow none "$FILE"
 exit 0

--- a/templates/scripts/agents/contract-metrics-agent.sh
+++ b/templates/scripts/agents/contract-metrics-agent.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# scripts/agents/contract-metrics-agent.sh
+# SCHEDULE: weekly monday 06:50
+#
+# Snapshots contract-layer hook telemetry into docs/agents/contract-metrics-report.md
+# so the impact of the contract layer can be reviewed over time. Purely
+# DETERMINISTIC — it runs the Python aggregator only; no Claude CLI, no API cost,
+# no auth needed (unlike the other scheduled agents).
+#
+# Discovered by install-agents.sh via the SCHEDULE comment above. Staggered to
+# 06:50 (after the documented agents at 06:30/06:45) per the stagger guidance in
+# methodology/scheduled-agents.md.
+#
+# Report lifecycle follows Rule #70: docs/agents/ is gitignored on public repos
+# (the report stays local) and tracked on private repos (committed by /triage).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+LOG="${PROJECT_DIR}/.claude/metrics/contract-events.jsonl"
+METRICS_SCRIPT="${PROJECT_DIR}/.claude/scripts/contract-metrics.py"
+OUT_DIR="${PROJECT_DIR}/docs/agents"
+OUT="${OUT_DIR}/contract-metrics-report.md"
+
+if [ ! -f "${METRICS_SCRIPT}" ]; then
+  echo "contract-metrics.py not found at ${METRICS_SCRIPT}" >&2
+  exit 1
+fi
+
+mkdir -p "${OUT_DIR}"
+
+{
+  echo "> Generated $(date -u +%Y-%m-%dT%H:%M:%SZ) by contract-metrics-agent"
+  echo
+  python3 "${METRICS_SCRIPT}" "${LOG}"
+} > "${OUT}"
+
+echo "Wrote ${OUT}"

--- a/templates/scripts/contract-metrics.py
+++ b/templates/scripts/contract-metrics.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""contract-metrics.py — aggregate contract-layer hook telemetry into a report.
+
+Reads the append-only JSONL audit log written by the contract-layer hooks
+(`guard-bash.sh`, `verify-edit.sh`) at `.claude/metrics/contract-events.jsonl`
+and reports whether the layer is doing anything measurable:
+
+  - block counts and block rate, per hook and per rule
+  - verify-edit SELF-CORRECTION rate: a block on a file followed by a later clean
+    edit of that same file in the same session = the corrective-hint loop closed
+  - week-over-week trend (blocks per 100 events) to spot agents internalizing
+    rules over time (declining block rate at stable volume)
+
+Stdlib only. Read-only. Best-effort: malformed log lines are skipped, never fatal.
+
+Usage:
+  contract-metrics.py [path]          # report on a log (default .claude/metrics/...)
+  contract-metrics.py --json [path]   # machine-readable metrics
+  contract-metrics.py --self-test     # prove the math on a synthetic fixture
+
+Exit codes: 0 = ok (including "no data yet"); 1 = self-test failed; 2 = bad usage.
+"""
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime
+
+DEFAULT_LOG = ".claude/metrics/contract-events.jsonl"
+
+
+def iso_week(ts):
+    """Return 'YYYY-Www' for an ISO-8601 'Z' timestamp, or None if unparseable."""
+    try:
+        dt = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ")
+    except (ValueError, TypeError):
+        return None
+    y, w, _ = dt.isocalendar()
+    return f"{y}-W{w:02d}"
+
+
+def parse_events(lines):
+    """Parse JSONL lines into event dicts, skipping blanks and malformed rows."""
+    events = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(obj, dict):
+            events.append(obj)
+    return events
+
+
+def compute(events):
+    """Reduce a list of event dicts to the metrics the report renders."""
+    m = {
+        "total": len(events),
+        "by_hook": Counter(),
+        "by_hook_block": Counter(),
+        "by_rule_block": Counter(),
+        "files_block": Counter(),
+        "weekly": defaultdict(lambda: {"events": 0, "blocks": 0}),
+        "first_ts": None,
+        "last_ts": None,
+    }
+    # (session_id, file) -> [(ts, decision), ...] for verify-edit self-correction
+    groups = defaultdict(list)
+
+    for e in events:
+        hook = e.get("hook", "?")
+        decision = e.get("decision", "?")
+        rule = e.get("rule", "none")
+        ts = e.get("ts", "") or ""
+        file = e.get("file", "") or ""
+
+        m["by_hook"][hook] += 1
+        if ts:
+            if m["first_ts"] is None or ts < m["first_ts"]:
+                m["first_ts"] = ts
+            if m["last_ts"] is None or ts > m["last_ts"]:
+                m["last_ts"] = ts
+        wk = iso_week(ts)
+        if wk:
+            m["weekly"][wk]["events"] += 1
+
+        if decision == "block":
+            m["by_hook_block"][hook] += 1
+            m["by_rule_block"][f"{hook}:{rule}"] += 1
+            if wk:
+                m["weekly"][wk]["blocks"] += 1
+            if hook == "verify-edit" and file:
+                m["files_block"][file] += 1
+
+        if hook == "verify-edit" and file:
+            groups[(e.get("session_id", "") or "", file)].append((ts, decision))
+
+    # Self-correction: a block is "corrected" if a later clean allow lands on the
+    # same file in the same session (the agent took the hint and fixed it).
+    sc_blocks = sc_corrected = 0
+    for evs in groups.values():
+        evs.sort(key=lambda x: x[0])
+        for i, (_, decision) in enumerate(evs):
+            if decision == "block":
+                sc_blocks += 1
+                if any(d == "allow" for (_, d) in evs[i + 1:]):
+                    sc_corrected += 1
+    m["sc_blocks"] = sc_blocks
+    m["sc_corrected"] = sc_corrected
+    return m
+
+
+def _pct(num, den):
+    return (100.0 * num / den) if den else 0.0
+
+
+def render(m):
+    """Render the metrics dict as a human-readable markdown report."""
+    out = []
+    out.append("# Contract Layer Metrics")
+    if not m["total"]:
+        out.append("")
+        out.append("No events logged yet. The hooks write one row per evaluated")
+        out.append("edit/command once projects start using the contract layer.")
+        return "\n".join(out) + "\n"
+
+    span = ""
+    if m["first_ts"] and m["last_ts"]:
+        span = f" | {m['first_ts'][:10]} .. {m['last_ts'][:10]}"
+    out.append(f"> {m['total']} events{span}")
+    out.append("")
+
+    out.append("## Blocks by hook")
+    out.append("")
+    out.append("| Hook | Events | Blocks | Block rate |")
+    out.append("|------|--------|--------|------------|")
+    for hook in sorted(m["by_hook"]):
+        ev = m["by_hook"][hook]
+        bl = m["by_hook_block"][hook]
+        out.append(f"| {hook} | {ev} | {bl} | {_pct(bl, ev):.1f}% |")
+    out.append("")
+
+    out.append("## Blocks by rule")
+    out.append("")
+    out.append("| Hook:Rule | Blocks |")
+    out.append("|-----------|--------|")
+    for rule, n in m["by_rule_block"].most_common():
+        out.append(f"| {rule} | {n} |")
+    if not m["by_rule_block"]:
+        out.append("| (none) | 0 |")
+    out.append("")
+
+    out.append("## verify-edit self-correction")
+    out.append("")
+    out.append("Did the agent fix the file after a block (same file, same session)?")
+    out.append("")
+    rate = _pct(m["sc_corrected"], m["sc_blocks"])
+    out.append(f"- Blocks: {m['sc_blocks']}")
+    out.append(f"- Corrected by a later clean edit: {m['sc_corrected']}")
+    out.append(f"- **Self-correction rate: {rate:.1f}%**")
+    out.append("")
+
+    if m["files_block"]:
+        out.append("## Top files by verify-edit blocks")
+        out.append("")
+        for file, n in m["files_block"].most_common(10):
+            out.append(f"- {file}: {n}")
+        out.append("")
+
+    out.append("## Weekly trend (blocks per 100 events)")
+    out.append("")
+    out.append("Declining rate at stable volume = agents internalizing the rules.")
+    out.append("")
+    out.append("| Week | Events | Blocks | Blocks/100 |")
+    out.append("|------|--------|--------|------------|")
+    for wk in sorted(m["weekly"]):
+        ev = m["weekly"][wk]["events"]
+        bl = m["weekly"][wk]["blocks"]
+        out.append(f"| {wk} | {ev} | {bl} | {_pct(bl, ev):.1f} |")
+    out.append("")
+    return "\n".join(out) + "\n"
+
+
+def metrics_to_json(m):
+    """Flatten the metrics dict to plain JSON-serializable types."""
+    return {
+        "total": m["total"],
+        "by_hook": dict(m["by_hook"]),
+        "by_hook_block": dict(m["by_hook_block"]),
+        "by_rule_block": dict(m["by_rule_block"]),
+        "files_block": dict(m["files_block"]),
+        "self_correction": {
+            "blocks": m["sc_blocks"],
+            "corrected": m["sc_corrected"],
+            "rate_pct": round(_pct(m["sc_corrected"], m["sc_blocks"]), 1),
+        },
+        "weekly": {wk: dict(v) for wk, v in m["weekly"].items()},
+        "first_ts": m["first_ts"],
+        "last_ts": m["last_ts"],
+    }
+
+
+SELF_TEST_EVENTS = [
+    {"ts": "2026-06-01T10:00:00Z", "session_id": "A", "hook": "verify-edit",
+     "decision": "block", "rule": "emoji", "file": "x.md"},
+    {"ts": "2026-06-01T10:05:00Z", "session_id": "A", "hook": "verify-edit",
+     "decision": "allow", "rule": "none", "file": "x.md"},
+    {"ts": "2026-06-01T10:10:00Z", "session_id": "A", "hook": "verify-edit",
+     "decision": "block", "rule": "emoji", "file": "y.md"},
+    {"ts": "2026-06-02T11:00:00Z", "session_id": "A", "hook": "guard-bash",
+     "decision": "block", "rule": "error-44", "file": ""},
+    {"ts": "2026-06-02T11:01:00Z", "session_id": "A", "hook": "guard-bash",
+     "decision": "allow", "rule": "none", "file": ""},
+    {"ts": "2026-06-09T09:00:00Z", "session_id": "B", "hook": "verify-edit",
+     "decision": "allow", "rule": "none", "file": "z.md"},
+]
+
+
+def self_test():
+    m = compute(SELF_TEST_EVENTS)
+    checks = [
+        ("total", m["total"], 6),
+        ("verify-edit events", m["by_hook"]["verify-edit"], 4),
+        ("guard-bash events", m["by_hook"]["guard-bash"], 2),
+        ("verify-edit blocks", m["by_hook_block"]["verify-edit"], 2),
+        ("guard-bash blocks", m["by_hook_block"]["guard-bash"], 1),
+        ("emoji blocks", m["by_rule_block"]["verify-edit:emoji"], 2),
+        ("sc_blocks", m["sc_blocks"], 2),
+        ("sc_corrected", m["sc_corrected"], 1),
+        # 06-01 and 06-02 are the same ISO week (W23); 06-09 is W24 -> 2 weeks.
+        ("weeks tracked", len(m["weekly"]), 2),
+    ]
+    ok = True
+    for name, got, want in checks:
+        if got != want:
+            ok = False
+            print(f"SELF-TEST FAIL: {name} = {got}, expected {want}")
+    if ok:
+        # render must not raise on real data
+        render(m)
+        print("SELF-TEST PASS: 9 checks across 2 sessions/weeks")
+        return 0
+    return 1
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Aggregate contract-layer hook telemetry.")
+    ap.add_argument("path", nargs="?", default=DEFAULT_LOG,
+                    help=f"JSONL event log (default {DEFAULT_LOG})")
+    ap.add_argument("--json", action="store_true", help="emit JSON instead of a report")
+    ap.add_argument("--self-test", action="store_true", help="run the built-in fixture test")
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    try:
+        with open(args.path, encoding="utf-8") as fh:
+            events = parse_events(fh)
+    except FileNotFoundError:
+        # No log yet is a normal early state, not an error.
+        if args.json:
+            print(json.dumps({"total": 0, "note": "no log file yet"}))
+        else:
+            print(f"# Contract Layer Metrics\n\nNo log at {args.path} yet.")
+        return 0
+
+    m = compute(events)
+    if args.json:
+        print(json.dumps(metrics_to_json(m), indent=2))
+    else:
+        sys.stdout.write(render(m))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a measurement layer so you can evaluate whether the contract layer actually changes agent behavior, instead of trusting it blindly. Answers the "set some metrics in place and review in a couple months" ask.

## What landed

- **Hook telemetry.** `guard-bash.sh` and `verify-edit.sh` append one **fail-open** JSONL row per evaluated command/edit to `.claude/metrics/contract-events.jsonl` — `{ts, session_id, hook, decision, rule, file}`. Never logs command text or file contents (guard-bash sees commands that may carry tokens); any logging error is swallowed so telemetry can't break a hook.
- **`contract-metrics.py`** (stdlib, `--self-test`): block rate per hook/rule, a verify-edit **self-correction rate** (a block followed by a clean re-edit of the same file in the same session = the corrective-hint loop closing), and a week-over-week trend (blocks per 100 events).
- **`contract-metrics-agent.sh`**: deterministic weekly snapshot to `docs/agents/contract-metrics-report.md`. No Claude CLI, no API cost, no auth.
- **Plumbing:** `.claude/metrics/` gitignored; report follows Rule #70; CI runs the new self-test and shellchecks the agent.

## Why these metrics

- **Self-correction rate is the cleanest signal** — it's within-session, so it sidesteps confounds (model updates, changing project mix) that muddy the raw trend.
- The feature is new, so ship day is a clean `t=0`; no pre-feature baseline to reconstruct.

## Verification

- shellcheck clean on all hooks + the agent; both Python scripts `py_compile` + `--self-test` pass.
- Twins byte-identical (verify-edit, contract-metrics); guard-bash divergence still confined to the #48 block.
- End-to-end: fired the real hooks, confirmed they write events, and the aggregator computed the self-correction rate correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)