### PR TITLE
release: v1.23.0 -- contract-layer impact metrics

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "cc-rpi",
       "source": "./",
       "description": "Research-Plan-Implement methodology, domain skills, and a 63-pattern agent-error knowledge base for Claude Code.",
-      "version": "1.22.0"
+      "version": "1.23.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "cc-rpi",
   "displayName": "cc-rpi -- RPI Methodology",
   "description": "Research-Plan-Implement methodology for Claude Code: phased workflow commands, domain skills, and a 63-pattern agent-error knowledge base.",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "author": {
     "name": "Juan Gonzalez"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.23.0] - 2026-06-23
+
 ### Added
 
 - **Contract-layer metrics (impact measurement).** The `guard-bash.sh` and

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cc-rpi — Claude Code Reference & Project Intelligence
 
 [![CI](https://github.com/juan294/cc-rpi/actions/workflows/validate.yml/badge.svg)](https://github.com/juan294/cc-rpi/actions/workflows/validate.yml)
-[![Version: v1.22.0](https://img.shields.io/badge/Version-v1.22.0-orange.svg)](https://github.com/juan294/cc-rpi/releases/tag/v1.22.0)
+[![Version: v1.23.0](https://img.shields.io/badge/Version-v1.23.0-orange.svg)](https://github.com/juan294/cc-rpi/releases/tag/v1.23.0)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Status: Active](https://img.shields.io/badge/Status-Active-brightgreen.svg)]()
 [![Claude Code](https://img.shields.io/badge/Built%20for-Claude%20Code-blueviolet.svg)](https://docs.anthropic.com/en/docs/claude-code)


### PR DESCRIPTION
Release **v1.23.0**. Squash-merge to `main`, then tag.

## [1.23.0] - 2026-06-23

### Added
- **Contract-layer metrics (impact measurement).** Hook telemetry (`guard-bash.sh` + `verify-edit.sh` append fail-open JSONL events to `.claude/metrics/contract-events.jsonl` — decision/rule/file/session, never command text or file contents), `contract-metrics.py` aggregator (block rates per hook/rule, verify-edit self-correction rate, week-over-week trend), and a deterministic weekly `contract-metrics-agent.sh` snapshot (no Claude CLI / no cost) to `docs/agents/contract-metrics-report.md`. Raw log gitignored; report follows Rule #70.

Lets the contract layer's impact be evaluated months from now instead of trusted blindly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)