### PR TITLE
docs(blueprint): harden ways-of-working from usage-insights review

### DIFF
--- a/methodology/agent-design.md
+++ b/methodology/agent-design.md
@@ -305,6 +305,24 @@ When N agents each push independently, every push triggers M workflow runs (CI m
 - No merge conflicts — main agent can detect shared-file edits before pushing
 - Cheaper GitHub Actions minutes — especially on macOS runners (10x cost multiplier)
 
+### Scope Discipline and the Watchdog
+
+The most expensive multi-agent failure is not a wrong fix — it is a **runaway
+agent** that keeps working after its job is done, or a **duplicate agent** that
+redoes work a sibling already committed. Both burn hours and tokens silently.
+
+Three orchestrator obligations prevent it:
+
+| Obligation | Rule |
+|------------|------|
+| **Scoped spawn** | Every agent gets a single-sentence task and an explicit terminal condition ("stop the moment X is true"). Never spawn with open-ended verbs like "look into" or "investigate" — they have no natural stopping point. |
+| **Watchdog budget** | Assign a wall-clock budget (~15–20 min for a focused fix). If an agent is still running past it, kill it and inspect rather than assuming progress. Require periodic status checkpoints on long fan-outs so a stuck agent is visible. |
+| **Dedup gate** | Before an agent does or continues work, it checks real repo state (`git log`, `git status`, `grep` for the artifact). If the work already landed on the branch, it stops and reports instead of producing a duplicate. |
+
+This pairs with the central-commit pattern: the main agent owns the watchdog
+because it owns the merge. A worktree agent cannot see its siblings — so the
+orchestrator, not the agent, is responsible for noticing redundant work.
+
 ---
 
 ## Claude Code Extension Points

--- a/methodology/ci-and-guardrails.md
+++ b/methodology/ci-and-guardrails.md
@@ -292,6 +292,28 @@ Beyond automated checks, guardrails include process rules that prevent common mi
 - **Regular audits** — `pnpm audit` / `npm audit` in CI catches known vulnerabilities.
 - **License compliance** — No copyleft dependencies in proprietary projects.
 
+### Code Scanning Requires GHAS
+
+A CodeQL / code-scanning workflow only runs if GitHub Advanced Security
+(GHAS) is enabled for the repo. Adding the workflow without GHAS makes it
+**fail CI on every push** — a self-inflicted red that has cost more than one
+triage cycle to discover and remove.
+
+- **Never add a CodeQL/code-scanning workflow speculatively.** Confirm GHAS
+  first:
+
+  ```bash
+  # Non-403 means code scanning is available; 403 means GHAS is off.
+  gh api repos/{owner}/{repo}/code-scanning/alerts >/dev/null 2>&1 && echo "GHAS on" || echo "GHAS off"
+  ```
+
+- GHAS is free on public repos but a **paid add-on on private repos**. On a
+  private repo, treat "enable GHAS" as a human decision (it has a cost), not
+  an autonomous fix.
+- `/triage` still *queries* existing code-scanning alerts (that query failing
+  is itself a YELLOW finding) — but querying alerts and *creating the
+  scanner* are different acts. Only the first is always safe.
+
 ## Guardrails and Agent Autonomy
 
 Guardrails are what make agent autonomy safe. When pre-commit hooks

--- a/methodology/scheduled-agents.md
+++ b/methodology/scheduled-agents.md
@@ -351,6 +351,32 @@ if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
 fi
 ```
 
+### Checkpoint and Resume
+
+Multi-step headless runs (nightly triage, blueprint sync, release agents) die
+mid-flight on transient `Not logged in`, API 500, or 529 overload errors. Without
+a checkpoint, the next attempt restarts from scratch — re-doing committed work and
+sometimes never finishing. Write a step marker after each major phase so a retry
+resumes where it left off:
+
+```bash
+CKPT="${TMPDIR:-/tmp}/${AGENT_NAME}.checkpoint"
+done_step() { grep -qxF "$1" "$CKPT" 2>/dev/null; }
+mark_step() { echo "$1" >> "$CKPT"; }
+
+# Each phase is guarded by its checkpoint, so a resumed run skips finished work.
+done_step "discover" || { run_discovery && mark_step "discover"; }
+done_step "fix"      || { run_fixes     && mark_step "fix"; }
+done_step "merge"    || { run_merges    && mark_step "merge"; }
+
+# Clear the checkpoint only on a fully successful run.
+rm -f "$CKPT"
+```
+
+Pair this with the retry loop above: the retry handles a flaky single call;
+the checkpoint handles a session that dies between phases. Commands that already
+support phase resume (for example `/remediate wave=N`) follow this same shape.
+
 ### WIP Limits
 
 For agents that produce work items requiring human review (like research or planning agents), enforce a WIP limit to prevent accumulating more unreviewed work than humans can handle:

--- a/patterns/quick-reference.md
+++ b/patterns/quick-reference.md
@@ -183,6 +183,20 @@ Skills: `[skill:name]` points to `.claude/skills/name/` for full examples.
 
 75. **Measure cost per outcome before betting beyond the floor** `[frequent]` -- track cost per merged PR and per workflow run, not per token. Stand up the weekly cost-report agent before investing in custom agents or large fan-outs, so you can confirm net-positive ROI instead of assuming it.
 
+## Multi-Agent Safety `[skill:multi-agent]`
+
+78. **Spawn agents with a terminal condition, watchdog the rest** `[situational]` -- every spawned agent gets a single-sentence task and an explicit stop condition ("stop the moment X is true"); never open-ended "look into"/"investigate". Set a ~15-20 min wall-clock budget and kill agents that overrun rather than assuming progress. Prevents the runaway agent that works hours past completion. See [agent-design.md](../methodology/agent-design.md).
+
+79. **Dedup against repo state before doing or continuing work** `[situational]` -- before an agent starts or resumes, check `git log`/`git status`/`grep` for the artifact. If a sibling already landed it, stop and report -- don't produce a duplicate (e.g. a second copy of a test block already on the branch). The orchestrator owns this check; worktree agents can't see each other.
+
+## Code & Edit Discipline
+
+80. **Verify an API supports a call before chaining on it** `[frequent]` -- confirm a method/type actually exists (docs, types, or a tiny probe) before building on it, and run the targeted test BEFORE committing the first attempt, not after. About a quarter of sessions started with a fix that didn't typecheck and needed a full revert (e.g. chaining `.abortSignal()` after a Supabase `.single()` that doesn't return it).
+
+81. **Format markdown tables programmatically, never by hand** `[universal]` `[hook-enforced]` -- run `markdownlint --fix`/`prettier --write` to align tables; never byte-tweak column padding to satisfy the linter. Hand-alignment is slow, regresses on the next edit, and is exactly what the `verify-edit.sh` markdownlint gate automates.
+
+82. **No CodeQL workflow without GHAS** `[github]` -- a code-scanning workflow fails CI on every push unless GitHub Advanced Security is enabled. Confirm first (`gh api repos/{owner}/{repo}/code-scanning/alerts` returns non-403) before adding the workflow. GHAS is free on public repos but a paid add-on on private repos -- on private, enabling it is a human cost decision, not an autonomous fix. Querying existing alerts (what `/triage` does) is always safe; creating the scanner is not. See [ci-and-guardrails.md](../methodology/ci-and-guardrails.md).
+
 ---
 
 For detailed symptoms, root causes, and examples, see [agent-errors.md](agent-errors.md).

--- a/templates/skills/git-workflow/SKILL.md
+++ b/templates/skills/git-workflow/SKILL.md
@@ -79,6 +79,36 @@ git worktree remove --force <path>; git branch -D <branch>
 
 Always remove worktrees BEFORE merging PRs with `--delete-branch`.
 
+## Cleanup After Merge
+
+Wrong -- assume the merge cleaned up; leave stale local branches behind
+(a cleanup "done" that left two local branches needing a second pass):
+
+```bash
+gh pr merge --squash --delete-branch   # deletes the REMOTE branch only
+```
+
+Right -- a complete cleanup covers worktrees, local branches, and prune,
+then verifies nothing is left dangling:
+
+```bash
+# 1. Remove worktrees FIRST (a branch checked out in a worktree won't delete)
+git worktree remove --force /absolute/path/to/worktree
+git worktree prune
+
+# 2. Delete the local branch (remote went with --delete-branch at merge)
+git branch -D <branch>
+
+# 3. Drop stale remote-tracking refs for branches deleted on the remote
+git fetch --prune
+
+# 4. Verify -- these should list ONLY active work, nothing merged
+git branch --merged                # local branches already merged
+git worktree list                  # lingering worktrees
+```
+
+Anything still listed in step 4 is the "second pass" -- finish it now, not later.
+
 ## Conflict Resolution
 
 Wrong -- plain checkout fails on unmerged files:

--- a/templates/skills/multi-agent/SKILL.md
+++ b/templates/skills/multi-agent/SKILL.md
@@ -92,3 +92,48 @@ Right -- break work so each teammate owns different files:
 Teammate A: edit src/api/auth-routes.ts
 Teammate B: edit src/api/user-routes.ts
 ```
+
+## Scope & Watchdog
+
+Wrong -- open-ended task, no stop condition: the agent keeps investigating
+long after its real work is done (a fork agent ran 2+ hours past completion).
+
+```text
+"Look into the Chapa failures and fix what you find."
+```
+
+Right -- one-sentence scope with an explicit terminal condition:
+
+```text
+"Fix the failing applyRateLimit test in src/rate-limit.test.ts so the suite
+is green. STOP the moment that test passes -- do not investigate other
+failures, refactor, or open new threads. Report back with the diff."
+```
+
+Rules for the orchestrator:
+
+- Give every spawned agent a **single-sentence scope** and a **terminal
+  condition** ("stop the moment X is true"). No open-ended "look into".
+- Set a **wall-clock budget** (~15-20 min for a focused fix). If an agent
+  is still running past it, kill it and inspect -- don't let it spin.
+- Require a **progress checkpoint** for long fan-outs: agents report status
+  every few files so a stuck agent is visible, not silent.
+
+## Dedup Before Continuing
+
+Wrong -- an agent resumes work a sibling already committed, producing a
+duplicate (e.g. a second `applyRateLimit` test block already on the branch).
+
+```text
+Agent B keeps adding tests without checking what Agent A committed.
+```
+
+Right -- check the actual repo state before doing or continuing work:
+
+```bash
+git log --oneline -10        # has a sibling already landed this?
+git status                   # is the change already staged/committed?
+grep -rn "applyRateLimit" test/   # does the artifact already exist?
+```
+
+If the work is already done, stop and report -- do not redo it.


### PR DESCRIPTION
## Summary

- **5 new operational rules (#78–82):** multi-agent scope discipline, dedup gate, API-existence verification, markdown table formatting, and CodeQL/GHAS gate — all sourced from real usage incidents
- **3 methodology expansions:** watchdog/scope section in `agent-design.md`, GHAS prerequisite warning in `ci-and-guardrails.md`, checkpoint-and-resume pattern in `scheduled-agents.md`
- **2 skill upgrades:** `git-workflow` gains a complete post-merge cleanup recipe; `multi-agent` gains Scope & Watchdog + Dedup Before Continuing examples

## Changes by file

| File | Change |
|------|--------|
| `patterns/quick-reference.md` | Rules #78–82: Multi-Agent Safety + Code & Edit Discipline sections |
| `methodology/agent-design.md` | "Scope Discipline and the Watchdog" -- orchestrator obligations table |
| `methodology/ci-and-guardrails.md` | "Code Scanning Requires GHAS" -- check command, paid-add-on note |
| `methodology/scheduled-agents.md` | "Checkpoint and Resume" -- bash pattern for mid-flight crash recovery |
| `templates/skills/git-workflow/SKILL.md` | "Cleanup After Merge" -- worktree then local branch then prune then verify |
| `templates/skills/multi-agent/SKILL.md` | "Scope & Watchdog" + "Dedup Before Continuing" wrong/right examples |

## Test plan

- [ ] `npx markdownlint '**/*.md' --ignore node_modules --ignore .claude` passes
- [ ] New rules (#78-82) are cross-linked to their methodology source files
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFsYAWZaTmRzSHHn9JQAPF