### PR TITLE
release: v1.25.0 -- finding-as-hypothesis hardening (Error #64, Rule #83)

### DIFF
--- a/.claude/commands/pre-launch.md
+++ b/.claude/commands/pre-launch.md
@@ -16,6 +16,20 @@ Model tier: **opus** — Claude Opus 4.6. All specialists: `model: "opus"`.
 > nitpicks — if the same issue appears in 5 places, report it once as a
 > systemic pattern, not five times as nitpicks.
 
+### Second-order rule
+
+A finding is a hypothesis, not a work order. Before you recommend a fix,
+reason one step past it: what must stay true after the change, and what
+could the fix break? A change that resolves your finding but regresses
+another property is not an improvement — surface the trade instead of
+presupposing the win is worth it. Prefer the narrowest fix that trades
+nothing away. When a non-functional goal (perf, ISR, bundle size, build
+time) conflicts with a correctness, security, or UX invariant, default to
+the invariant and flag the conflict for a human decision — do not silently
+trade correctness for a metric. Capture this reasoning in the finding's
+**Regression risk** field; it is the anchor `/remediate` verifies against
+before implementing anything.
+
 ## Input
 
 Optional `$ARGUMENTS`: focus area hint (e.g., "focus on backend"). Biases
@@ -128,6 +142,11 @@ One entry per finding (use `####` heading + structured fields):
 - **What's happening:** <factual description>
 - **Why it matters:** <impact, tied to severity>
 - **Recommendation:** <concrete fix direction>
+- **Regression risk:** <invariants that must still hold after the fix, the
+  assumptions the recommendation depends on, and any property the fix trades
+  away. If the fix swaps one mechanism for another, state what the replacement
+  must cover for the swap to be valid. Write "none — isolated/additive change"
+  only after confirming nothing downstream depends on the behavior you touch.>
 - **Expected impact:** <what improves after the fix>
 - **Effort estimate:** S | M | L | XL
 ```
@@ -148,6 +167,10 @@ Rules:
 - Evidence/inference labeling is mandatory on every finding.
 - Prefer systemic findings: one pattern covering 5 instances > five
   separate nitpicks.
+- **Regression risk** is mandatory and is not boilerplate. A blanket
+  "none" on a finding that changes runtime behavior is a contract failure
+  — name the invariant or the trade. This is the field `/remediate`
+  verifies before it implements your recommendation.
 
 This contract is machine-checkable: `/remediate` runs
 `.claude/scripts/validate-findings.py` against the report before parsing and
@@ -292,7 +315,8 @@ doubt.
 ### Report Output
 
 - Path: `docs/agents/pre-launch-report.md`
-- Commit policy follows repo visibility (Rule #70): gitignored on public repos, tracked on private repos
+- Commit policy follows repo visibility (Rule #70): gitignored on public
+  repos, tracked on private repos
 - Markdown only. No XML tags.
 - Finding IDs are the `/remediate` parse anchor — never reuse an ID,
   never list a finding without an ID.

--- a/.claude/commands/remediate.md
+++ b/.claude/commands/remediate.md
@@ -53,8 +53,8 @@ Gather context before making any changes.
    - Each finding has structured fields (bold format:
      `**Severity:**`, `**Time horizon:**`, `**Evidence type:**`,
      `**Files:**`, `**What's happening:**`, `**Why it matters:**`,
-     `**Recommendation:**`, `**Expected impact:**`,
-     `**Effort estimate:**`).
+     `**Recommendation:**`, `**Regression risk:**`,
+     `**Expected impact:**`, `**Effort estimate:**`).
    - Parse every finding — never drop one.
 
 3. **Group related findings into work units:**
@@ -112,8 +112,8 @@ After user approval:
    gh issue create \
      --title "[remediate] <finding-id> <title>" \
      --body "<evidence type>, <file refs>, <what's happening>,
-   <why it matters>, <recommendation>, <expected impact>,
-   <effort>, <finding ID>" \
+   <why it matters>, <recommendation>, <regression risk>,
+   <expected impact>, <effort>, <finding ID>" \
      --label "<domain>,<severity>,<wave>"
    ```
 
@@ -140,28 +140,54 @@ After user approval:
 
    a. Read the GitHub issue and all source files in your ownership set.
 
-   b. **TDD: Write a failing test FIRST** that captures the finding.
-      For non-testable findings (documentation, configuration, CI
-      changes), skip directly to implementation.
+   b. **Verify the recommendation before implementing it.** The finding's
+      Recommendation is a hypothesis, not an order. Before writing any code:
 
-   c. Implement the minimum fix to make the test pass.
+      - Read the **Regression risk** field. Independently confirm each
+        assumption it states actually holds — trace the real code paths,
+        don't take the finding's word. If the fix swaps mechanism X for
+        mechanism Y, verify Y covers every input X handles (every locale
+        source, every auth path, every caller), not just the one the
+        finding names.
+      - Identify the user-facing invariant the fix could break. Your
+        failing test in step (c) must assert that invariant survives —
+        not merely that the finding's symptom is gone. (Guard "the English
+        cookie user still sees an English body," not only "ISR is
+        restored.")
+      - If verification shows the recommendation is incomplete, wrong, or
+        trades away an invariant: **STOP. Do not implement.** Return to the
+        orchestrator with what you found and the unresolved trade. Halting
+        one finding beats shipping a regression.
 
-   d. Run verification sequentially:
+   c. **TDD: Write a failing test FIRST** that captures the finding AND
+      guards the invariant identified in step (b). For non-testable
+      findings (documentation, configuration, CI changes), skip directly
+      to implementation.
+
+   d. Implement the minimum fix to make the test pass.
+
+   e. Run verification sequentially:
 
       ```bash
       $TEST_CMD; $TYPECHECK_CMD; $LINT_CMD
       ```
 
-   e. Run `/simplify` on changed files.
+   f. Run `/simplify` on changed files.
 
-   f. Run verification again (in case `/simplify` introduced changes).
+   g. Run verification again (in case `/simplify` introduced changes).
 
-   g. Commit with message: `fix: <issue-title> (#<issue-number>)`
+   h. Commit with message: `fix: <issue-title> (#<issue-number>)`
 
-   h. Do NOT push. The orchestrator handles all pushes.
+   i. Do NOT push. The orchestrator handles all pushes.
 
 3. **Monitor Wave 1 agent progress.** As agents complete, log their
-   status (pass/fail, tests added, files modified).
+   status (pass/fail, tests added, files modified). If an agent **halted**
+   under step (b) — the recommendation failed verification or trades away
+   an invariant — do NOT auto-implement an alternative and do NOT silently
+   drop it. Collect every halted finding and surface it to the human with
+   the unresolved trade. The issue stays open; the finding is reported as
+   "halted — recommendation unsafe, needs human re-scope," not as resolved
+   (Rule #58 coverage is satisfied by the open issue).
 
 4. **Wave 3 — file-only.** Issues were created in step 1. No worktree
    agents are spawned for Wave 3. Report these as "filed, not fixed"
@@ -292,6 +318,7 @@ Generate a remediation report at `docs/agents/remediation-report.md`:
 - Issues created: [N]
 - Issues resolved (merged): [N] (Wave 1: X, Wave 2: Y)
 - Issues filed only (not fixed): [Z] (Wave 3)
+- Halted (recommendation unsafe — needs human re-scope): [N]
 - Tests added: [N]
 - Files modified: [N]
 - CI status: PASSING / FAILING
@@ -336,6 +363,12 @@ Present the report summary to the user.
 - **TDD mandatory.** Each agent writes a failing test before
   implementing. The only exception is non-testable work
   (documentation, configuration, CI changes).
+- **Recommendation is a hypothesis.** Verify the finding's assumptions in
+  real code before implementing (worktree step b). The guard test asserts
+  the invariant the fix could break, not just the finding's symptom. A
+  recommendation that fails verification or trades away a correctness,
+  security, or UX invariant **halts** — escalate to the human, never
+  auto-implement it literally.
 - **Agents do NOT push** (Central Commit Rule). Only the orchestrator
   pushes. Worktree agents commit locally, orchestrator batch-pushes.
 - **Sequential merges.** Merge PRs one at a time, test after each.

--- a/.claude/scripts/validate-findings.py
+++ b/.claude/scripts/validate-findings.py
@@ -36,6 +36,7 @@ REQUIRED_FIELDS = [
     "What's happening",
     "Why it matters",
     "Recommendation",
+    "Regression risk",
     "Expected impact",
     "Effort estimate",
 ]
@@ -129,6 +130,7 @@ VALID_FIXTURE = """## 5. Backend
 - **What's happening:** the list endpoint issues one query per row.
 - **Why it matters:** p95 latency scales with result size.
 - **Recommendation:** batch the lookups with a single join.
+- **Regression risk:** join must preserve per-row ordering the UI relies on.
 - **Expected impact:** flat latency under load.
 - **Effort estimate:** M
 
@@ -148,6 +150,7 @@ INVALID_FIXTURE = """## 5. Backend
 - **What's happening:** x
 - **Why it matters:** y
 - **Recommendation:** z
+- **Regression risk:** none — additive index only.
 - **Expected impact:** w
 - **Effort estimate:** M
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.25.0] - 2026-06-26
+
+### Added
+
+- **Error #64 + Rule #83 — "a finding's recommendation is a hypothesis":**
+  new error pattern (`patterns/agent-errors.md`) and paired rule
+  (`patterns/quick-reference.md`) for the failure where a remediation agent
+  implements an audit finding's proposed fix literally and breaks a
+  correctness/UX invariant the fix never verified. Real case: a Performance
+  finding traded server-side locale resolution for ISR on the highest-traffic
+  route, breaking i18n for every cookie-based (returning) user — the symptom
+  test ("ISR restored") passed; no test guarded "English user sees an English
+  body". Error count: 63 → 64. Rule count: 82 → 83.
+- **Required `Regression risk` field on every pre-launch finding** — the
+  Output Contract (`pre-launch.md`) now mandates an
+  invariants/assumptions/trade-offs field, enforced before parsing by
+  `validate-findings.py` (added to required fields; bundled fixtures +
+  self-test updated).
+
+### Changed
+
+- **Pre-launch "Second-order rule"** (`pre-launch.md`) — a finding is a
+  hypothesis, not a work order. Specialists reason one step past each fix
+  and, when a non-functional goal (perf/ISR/bundle) conflicts with a
+  correctness/security/UX invariant, default to the invariant and flag the
+  trade rather than presupposing the win.
+- **Remediation verify-the-recommendation gate** (`remediate.md`) — worktree
+  agents independently confirm a finding's assumptions in real code and write
+  the guard test against the invariant (not the symptom) before implementing.
+  A recommendation that fails verification or trades away an invariant
+  **halts** and escalates to a human instead of being implemented literally.
+  Adds a "Halted" report line and a `/remediate` rule.
+
 ## [1.24.0] - 2026-06-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Blueprint repository for Claude Code projects, with Codex compatibility
 via `AGENTS.md` plus Codex-only helper skills in `.codex/skills/`.
-Contains the RPI methodology, 63 known agent error patterns, 82
+Contains the RPI methodology, 64 known agent error patterns, 83
 operational rules, and templates for CLAUDE.md, AGENTS.md, slash
 commands, skills, rules, and project setup.
 
@@ -87,8 +87,8 @@ Go directly to these paths -- never search the codebase for them.
 
 | Topic | Path | Notes |
 |-------|------|-------|
-| Error catalog | `patterns/agent-errors.md` | 63 errors, source of truth |
-| Operational rules | `patterns/quick-reference.md` | 82 rules with scope/stack tags |
+| Error catalog | `patterns/agent-errors.md` | 64 errors, source of truth |
+| Operational rules | `patterns/quick-reference.md` | 83 rules with scope/stack tags |
 | Deployment safety | `patterns/deployment-safety.md` | Resource efficiency rules |
 | Skill templates | `templates/skills/` | 10 domain skills |
 | Codex-only skills | `.codex/skills/` | Personal Codex helpers such as `codex-simplify` |

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -311,7 +311,7 @@ This sounds restrictive, but it's the single most impactful rule for research qu
 
 ### Error Prevention
 
-The blueprint includes 82 operational rules learned from real sessions. These aren't theoretical — they're patterns that caused actual failures and wasted time. Rather than loading all rules into every session, the blueprint uses **progressive disclosure** across three layers: a slim CLAUDE.md (~70 lines) for universal instructions, `.claude/rules/` for conditional rules that load only when working with matching files, and `.claude/skills/` for detailed domain knowledge that loads on demand. This keeps the agent's context window clean and focused.
+The blueprint includes 83 operational rules learned from real sessions. These aren't theoretical — they're patterns that caused actual failures and wasted time. Rather than loading all rules into every session, the blueprint uses **progressive disclosure** across three layers: a slim CLAUDE.md (~70 lines) for universal instructions, `.claude/rules/` for conditional rules that load only when working with matching files, and `.claude/skills/` for detailed domain knowledge that loads on demand. This keeps the agent's context window clean and focused.
 
 The 10 blueprint-provided skills cover: git workflow, CI verification, deployment safety, multi-agent coordination, GitHub CLI, Python, macOS, Supabase, error patterns, and systematic debugging. The 5 rule templates cover: RPI details, push accountability, deployment safety, Supabase, and testing.
 
@@ -458,8 +458,8 @@ The blueprint repository contains detailed documentation on every topic mentione
 | Testing approach | `methodology/testing.md` | TDD protocol, verification hierarchy |
 | CI ownership | `methodology/push-accountability.md` | Background CI monitoring, fix-and-repush |
 | Model economics | `methodology/cost-monitoring.md` | Cost pools, model-tier binding, access tiers, cost-per-outcome |
-| Error patterns | `patterns/agent-errors.md` | 63 documented errors with symptoms and solutions |
-| Operational rules | `patterns/quick-reference.md` | 82 rules with scope/stack tags, organized by domain |
+| Error patterns | `patterns/agent-errors.md` | 64 documented errors with symptoms and solutions |
+| Operational rules | `patterns/quick-reference.md` | 83 rules with scope/stack tags, organized by domain |
 | Domain skills | `templates/skills/` | 10 blueprint-provided skills for progressive disclosure |
 | Rule templates | `templates/rules/` | 5 conditional/modular rules for `.claude/rules/` |
 | Deployment safety | `patterns/deployment-safety.md` | Resource efficiency and production deployment rules |

--- a/methodology/four-phases.md
+++ b/methodology/four-phases.md
@@ -322,6 +322,26 @@ Implement (atomic change)
 
 **Reviewer powers:** The reviewer subagent can add tests to the verification checks, strengthening quality.
 
+**A recommendation is a hypothesis, not a work order.** When the work to
+implement comes from an upstream diagnosis — a pre-launch finding, a code
+review, an audit — the diagnosis is usually right but the proposed fix is
+narrow: it carries an unstated assumption that held for the one case the
+reviewer looked at. Before implementing it:
+
+- **Verify the assumption in real code.** If the fix swaps mechanism X for
+  mechanism Y, confirm Y covers every input X handled — every locale source,
+  auth path, caller — not just the one named.
+- **Guard the invariant, not the symptom.** The failing test asserts the
+  behavior the fix could break ("the English cookie user still sees an English
+  body"), not merely that the diagnosed symptom is gone ("ISR is restored").
+- **Halt on an unsafe trade.** If the fix trades a correctness, security, or UX
+  invariant for a non-functional metric (perf, ISR, bundle size), STOP and
+  escalate — that trade is a human decision, not an autonomous one.
+
+This is the implement-phase guard against Error #64 (Rule #83). `/remediate`
+encodes it as a per-finding gate; the same discipline applies any time you
+implement someone else's prescription.
+
 ### Phase Completion Criteria
 
 An implementation phase is **done** when:

--- a/patterns/agent-errors.md
+++ b/patterns/agent-errors.md
@@ -1,6 +1,6 @@
 # Known Agent Errors -- Universal Catalog
 
-63 documented error patterns from real recurring issues across projects.
+64 documented error patterns from real recurring issues across projects.
 Each entry: symptom, root cause, correct approach, anti-pattern.
 
 **Note:** This file is the source of truth for error patterns. The condensed
@@ -2332,3 +2332,26 @@ pytest -x --numprocesses=2
 ```
 
 **Key detail:** This compounds with Error #1 — if any agent's test run fails, sibling tool calls are killed, but the underlying test processes (spawned via Bash) continue running. The agent loses the ability to manage or cancel them. Prevention is the only fix: scope tests narrowly and limit concurrency.
+
+## Error #64: Agent implements a finding's recommendation literally, breaking an invariant the fix never checked
+
+**Symptom:** A code-review or pre-launch finding correctly diagnoses a real problem and proposes a fix. A remediation agent implements that fix exactly as written, the targeted symptom disappears, tests for the symptom pass — and a different, often higher-value behavior silently regresses. The diagnosis was right; the recommendation was incomplete; nobody verified the assumption the recommendation rested on before shipping it.
+
+**Root cause:** The agent treats a finding's `Recommendation` field as a work order rather than a hypothesis. A finding is written by a specialist with a partial mental model of one domain; its proposed fix usually carries an unstated assumption ("mechanism Y can replace mechanism X") that holds for the case the specialist looked at but not for every case in production. The remediation agent's TDD test guards the *symptom the finding named*, not the *invariant the fix could break*, so the regression sails through green tests. The deeper trap is a value swap: trading a correctness, security, or UX invariant for a non-functional metric (perf, ISR, bundle size) without anyone deciding that trade was worth it.
+
+Real example: A Performance Engineer finding (`FE-M1`) correctly identified that the highest-traffic route had lost ISR (Incremental Static Regeneration) because it called a server-side `getServerLocale()` on every request. The recommendation: move locale handling to a client component (`LocaleSync`) so the route could be statically generated again. The remediation agent implemented exactly that. But `LocaleSync` only read the `?lang=` URL param — it never read the locale **cookie**. `getServerLocale()` resolved locale from the cookie for returning users. So after the "fix," every returning English user (the cookie path) got a page body in the wrong language. The symptom test ("ISR is restored") passed; no test asserted "an English cookie user sees an English body." You cannot have both ISR and server-rendered per-user locale unless the whole page body moves to client components — a real architectural trade the finding never surfaced and nobody chose. The ISR win was not worth breaking i18n for all English users.
+
+**Correct approach — always do this:**
+
+- **Treat the recommendation as a hypothesis.** Before implementing, independently confirm its assumptions in the real code. If the fix swaps mechanism X for mechanism Y, verify Y covers *every* input X handled — every locale source, every auth path, every caller — not just the one the finding named.
+- **Author findings with a `Regression risk` field.** State the invariants that must still hold, the assumptions the fix depends on, and any property the fix trades away. A blanket "none" on a behavior-changing finding is a contract failure.
+- **Guard the invariant, not the symptom.** The TDD failing-test must assert the behavior the fix could break ("English cookie user still sees an English body"), not merely that the diagnosed symptom is gone ("ISR is restored").
+- **Halt on an unsafe trade.** If verification shows the recommendation is incomplete, wrong, or trades a correctness/security/UX invariant for a metric, STOP and escalate to a human with the unresolved trade. Halting one finding beats shipping a regression.
+
+**Never do this:**
+
+- Don't implement a finding's `Recommendation` verbatim because it came from an audit — audits diagnose well and prescribe narrowly.
+- Don't let "the symptom test is green" stand in for "nothing else broke." Symptom coverage is not invariant coverage.
+- Don't silently trade correctness for performance. If a fix forces that choice, it is a human decision, not an autonomous one.
+
+**Key detail:** The chain of failure has three independent links, and breaking any one stops it: (1) the finding states a `Regression risk` so the assumption is visible; (2) the implementer verifies that assumption against real code before writing the fix; (3) a test asserts the invariant, not the symptom. The contract enforces link 1 (`validate-findings.py` requires the field); the remediation gate enforces links 2 and 3. Maps to Rule #83.

--- a/patterns/quick-reference.md
+++ b/patterns/quick-reference.md
@@ -169,6 +169,8 @@ Skills: `[skill:name]` points to `.claude/skills/name/` for full examples.
 
 77. **No emojis in documentation** `[universal]` `[hook-enforced]` -- use text equivalents (PASS, `[x]`, `->`), not emoji/pictographs. Enforced post-edit by `verify-edit.sh` on `.md` files (arrows/dashes/box-drawing are allowed). Per-file opt-out: a line containing `<!-- contract:allow-emoji -->`.
 
+83. **A finding's recommendation is a hypothesis, not a work order** `[frequent]` -- a finding (pre-launch/audit/code-review) diagnoses well but prescribes narrowly. Before implementing, verify its assumptions in real code (if the fix swaps mechanism X for Y, confirm Y covers every input X handled, not just the one named) and write the guard test against the **invariant the fix could break**, not the symptom it names ("English cookie user still sees an English body", not just "ISR restored"). A fix that trades a correctness/security/UX invariant for a metric (perf, ISR, bundle size) **halts** -- escalate to a human, never implement it literally. Every pre-launch finding carries a required **Regression risk** field, enforced by `validate-findings.py` before `/remediate` parses. See [Error #64](agent-errors.md).
+
 ## Agent Reports
 
 70. **Agent report commit policy depends on repo visibility** `[universal]` -- check `gh repo view --json visibility` at setup time. **Public repos:** gitignore `docs/agents/`, `logs/`, `scripts/agents/` so operational details don't leak. Reports stay local; only code fixes are committed. **Private repos:** track all three directories. Triage commits reports alongside code fixes as historical artifacts.

--- a/templates/commands/pre-launch.md
+++ b/templates/commands/pre-launch.md
@@ -16,6 +16,20 @@ Model tier: **opus** — Claude Opus 4.6. All specialists: `model: "opus"`.
 > nitpicks — if the same issue appears in 5 places, report it once as a
 > systemic pattern, not five times as nitpicks.
 
+### Second-order rule
+
+A finding is a hypothesis, not a work order. Before you recommend a fix,
+reason one step past it: what must stay true after the change, and what
+could the fix break? A change that resolves your finding but regresses
+another property is not an improvement — surface the trade instead of
+presupposing the win is worth it. Prefer the narrowest fix that trades
+nothing away. When a non-functional goal (perf, ISR, bundle size, build
+time) conflicts with a correctness, security, or UX invariant, default to
+the invariant and flag the conflict for a human decision — do not silently
+trade correctness for a metric. Capture this reasoning in the finding's
+**Regression risk** field; it is the anchor `/remediate` verifies against
+before implementing anything.
+
 ## Input
 
 Optional `$ARGUMENTS`: focus area hint (e.g., "focus on backend"). Biases
@@ -128,6 +142,11 @@ One entry per finding (use `####` heading + structured fields):
 - **What's happening:** <factual description>
 - **Why it matters:** <impact, tied to severity>
 - **Recommendation:** <concrete fix direction>
+- **Regression risk:** <invariants that must still hold after the fix, the
+  assumptions the recommendation depends on, and any property the fix trades
+  away. If the fix swaps one mechanism for another, state what the replacement
+  must cover for the swap to be valid. Write "none — isolated/additive change"
+  only after confirming nothing downstream depends on the behavior you touch.>
 - **Expected impact:** <what improves after the fix>
 - **Effort estimate:** S | M | L | XL
 ```
@@ -148,6 +167,10 @@ Rules:
 - Evidence/inference labeling is mandatory on every finding.
 - Prefer systemic findings: one pattern covering 5 instances > five
   separate nitpicks.
+- **Regression risk** is mandatory and is not boilerplate. A blanket
+  "none" on a finding that changes runtime behavior is a contract failure
+  — name the invariant or the trade. This is the field `/remediate`
+  verifies before it implements your recommendation.
 
 This contract is machine-checkable: `/remediate` runs
 `.claude/scripts/validate-findings.py` against the report before parsing and
@@ -292,7 +315,8 @@ doubt.
 ### Report Output
 
 - Path: `docs/agents/pre-launch-report.md`
-- Commit policy follows repo visibility (Rule #70): gitignored on public repos, tracked on private repos
+- Commit policy follows repo visibility (Rule #70): gitignored on public
+  repos, tracked on private repos
 - Markdown only. No XML tags.
 - Finding IDs are the `/remediate` parse anchor — never reuse an ID,
   never list a finding without an ID.

--- a/templates/commands/remediate.md
+++ b/templates/commands/remediate.md
@@ -53,8 +53,8 @@ Gather context before making any changes.
    - Each finding has structured fields (bold format:
      `**Severity:**`, `**Time horizon:**`, `**Evidence type:**`,
      `**Files:**`, `**What's happening:**`, `**Why it matters:**`,
-     `**Recommendation:**`, `**Expected impact:**`,
-     `**Effort estimate:**`).
+     `**Recommendation:**`, `**Regression risk:**`,
+     `**Expected impact:**`, `**Effort estimate:**`).
    - Parse every finding — never drop one.
 
 3. **Group related findings into work units:**
@@ -112,8 +112,8 @@ After user approval:
    gh issue create \
      --title "[remediate] <finding-id> <title>" \
      --body "<evidence type>, <file refs>, <what's happening>,
-   <why it matters>, <recommendation>, <expected impact>,
-   <effort>, <finding ID>" \
+   <why it matters>, <recommendation>, <regression risk>,
+   <expected impact>, <effort>, <finding ID>" \
      --label "<domain>,<severity>,<wave>"
    ```
 
@@ -140,28 +140,54 @@ After user approval:
 
    a. Read the GitHub issue and all source files in your ownership set.
 
-   b. **TDD: Write a failing test FIRST** that captures the finding.
-      For non-testable findings (documentation, configuration, CI
-      changes), skip directly to implementation.
+   b. **Verify the recommendation before implementing it.** The finding's
+      Recommendation is a hypothesis, not an order. Before writing any code:
 
-   c. Implement the minimum fix to make the test pass.
+      - Read the **Regression risk** field. Independently confirm each
+        assumption it states actually holds — trace the real code paths,
+        don't take the finding's word. If the fix swaps mechanism X for
+        mechanism Y, verify Y covers every input X handles (every locale
+        source, every auth path, every caller), not just the one the
+        finding names.
+      - Identify the user-facing invariant the fix could break. Your
+        failing test in step (c) must assert that invariant survives —
+        not merely that the finding's symptom is gone. (Guard "the English
+        cookie user still sees an English body," not only "ISR is
+        restored.")
+      - If verification shows the recommendation is incomplete, wrong, or
+        trades away an invariant: **STOP. Do not implement.** Return to the
+        orchestrator with what you found and the unresolved trade. Halting
+        one finding beats shipping a regression.
 
-   d. Run verification sequentially:
+   c. **TDD: Write a failing test FIRST** that captures the finding AND
+      guards the invariant identified in step (b). For non-testable
+      findings (documentation, configuration, CI changes), skip directly
+      to implementation.
+
+   d. Implement the minimum fix to make the test pass.
+
+   e. Run verification sequentially:
 
       ```bash
       $TEST_CMD; $TYPECHECK_CMD; $LINT_CMD
       ```
 
-   e. Run `/simplify` on changed files.
+   f. Run `/simplify` on changed files.
 
-   f. Run verification again (in case `/simplify` introduced changes).
+   g. Run verification again (in case `/simplify` introduced changes).
 
-   g. Commit with message: `fix: <issue-title> (#<issue-number>)`
+   h. Commit with message: `fix: <issue-title> (#<issue-number>)`
 
-   h. Do NOT push. The orchestrator handles all pushes.
+   i. Do NOT push. The orchestrator handles all pushes.
 
 3. **Monitor Wave 1 agent progress.** As agents complete, log their
-   status (pass/fail, tests added, files modified).
+   status (pass/fail, tests added, files modified). If an agent **halted**
+   under step (b) — the recommendation failed verification or trades away
+   an invariant — do NOT auto-implement an alternative and do NOT silently
+   drop it. Collect every halted finding and surface it to the human with
+   the unresolved trade. The issue stays open; the finding is reported as
+   "halted — recommendation unsafe, needs human re-scope," not as resolved
+   (Rule #58 coverage is satisfied by the open issue).
 
 4. **Wave 3 — file-only.** Issues were created in step 1. No worktree
    agents are spawned for Wave 3. Report these as "filed, not fixed"
@@ -292,6 +318,7 @@ Generate a remediation report at `docs/agents/remediation-report.md`:
 - Issues created: [N]
 - Issues resolved (merged): [N] (Wave 1: X, Wave 2: Y)
 - Issues filed only (not fixed): [Z] (Wave 3)
+- Halted (recommendation unsafe — needs human re-scope): [N]
 - Tests added: [N]
 - Files modified: [N]
 - CI status: PASSING / FAILING
@@ -336,6 +363,12 @@ Present the report summary to the user.
 - **TDD mandatory.** Each agent writes a failing test before
   implementing. The only exception is non-testable work
   (documentation, configuration, CI changes).
+- **Recommendation is a hypothesis.** Verify the finding's assumptions in
+  real code before implementing (worktree step b). The guard test asserts
+  the invariant the fix could break, not just the finding's symptom. A
+  recommendation that fails verification or trades away a correctness,
+  security, or UX invariant **halts** — escalate to the human, never
+  auto-implement it literally.
 - **Agents do NOT push** (Central Commit Rule). Only the orchestrator
   pushes. Worktree agents commit locally, orchestrator batch-pushes.
 - **Sequential merges.** Merge PRs one at a time, test after each.

--- a/templates/scripts/validate-findings.py
+++ b/templates/scripts/validate-findings.py
@@ -36,6 +36,7 @@ REQUIRED_FIELDS = [
     "What's happening",
     "Why it matters",
     "Recommendation",
+    "Regression risk",
     "Expected impact",
     "Effort estimate",
 ]
@@ -129,6 +130,7 @@ VALID_FIXTURE = """## 5. Backend
 - **What's happening:** the list endpoint issues one query per row.
 - **Why it matters:** p95 latency scales with result size.
 - **Recommendation:** batch the lookups with a single join.
+- **Regression risk:** join must preserve per-row ordering the UI relies on.
 - **Expected impact:** flat latency under load.
 - **Effort estimate:** M
 
@@ -148,6 +150,7 @@ INVALID_FIXTURE = """## 5. Backend
 - **What's happening:** x
 - **Why it matters:** y
 - **Recommendation:** z
+- **Regression risk:** none — additive index only.
 - **Expected impact:** w
 - **Effort estimate:** M
 


### PR DESCRIPTION
## Why

An audit finding diagnoses well but prescribes narrowly. In a recent project, a Performance Engineer finding (`FE-M1`) correctly identified ISR loss on the highest-traffic route and recommended moving locale handling to a client `LocaleSync` component. The remediation agent implemented it literally — but `LocaleSync` only read the `?lang=` URL param, not the locale **cookie** that `getServerLocale()` resolved. Every returning English (cookie-based) user got a page body in the wrong language. The symptom test ("ISR restored") passed; no test guarded "English user sees an English body". The ISR win was not worth breaking i18n for all English users — and nobody chose that trade.

The failure chain has three independent links; breaking any one stops it. This release breaks all three.

## What changed

**Author side — pre-launch specialists (`pre-launch.md`)**
- New **Second-order rule**: a finding is a hypothesis, not a work order. Reason one step past the fix; when a non-functional goal (perf/ISR/bundle) conflicts with a correctness/security/UX invariant, default to the invariant and flag the trade.
- New required **`Regression risk`** field on every finding (invariants that must hold, assumptions the fix depends on, properties traded away). Anti-boilerplate clause: a blanket "none" on a behavior-changing finding is a contract failure.

**Consumer side — remediation worktree agents (`remediate.md`)**
- New **verify-the-recommendation gate** before TDD: confirm the finding's assumptions in real code (if the fix swaps mechanism X for Y, verify Y covers every input X handled), guard the **invariant** in the failing test (not the symptom), and **halt + escalate** on an unsafe trade instead of implementing literally. New "Halted" report line + `/remediate` rule.

**Enforcement (`validate-findings.py`)**
- `Regression risk` added to required fields, so `/remediate`'s deterministic gate rejects any report missing it *before parsing*. Fixtures + self-test updated (passing). Synced to both `.claude/` and `templates/`.

**Docs / methodology**
- Error #64, Rule #83, `methodology/four-phases.md` Implement-phase guard, count bumps (errors 63→64, rules 82→83), CHANGELOG `[1.25.0]`.

## Verification
- `validate-findings.py --self-test` passes (active + template copies).
- Touched command/template files lint clean at 80 cols.
- No new markdownlint issue *types* in content files (only house-style MD013/MD029, consistent with existing entries). CI = shellcheck (unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)