### PR TITLE
chore: harden /release version scan against missed files

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -26,9 +26,28 @@ Gather release context before making any changes.
    git log <last-tag>..HEAD --oneline
    ```
 
-4. **Identify all version-bearing files** -- scan for the current version string across the project:
-   manifests, README badges, install instructions, constants files, docker tags,
-   CI configs, documentation site configs.
+4. **Identify all version-bearing files** -- do NOT rely on memory or a static
+   list. Grep the CURRENT version string across the whole repo so nothing is
+   missed:
+
+   ```bash
+   git grep -n -F "1.2.3"; git grep -n -F "v1.2.3"   # both bare and v-prefixed
+   ```
+
+   Hand-maintained version strings drift silently when there is no canonical
+   manifest. Explicitly confirm these commonly-missed locations, even if a scoped
+   scan would skip them:
+   - **README/docs shield.io badges** -- the version can appear 3x on ONE line
+     (badge label text, the `img.shields.io` URL, and the `releases/tag/` link href).
+   - **Plugin/marketplace manifests** (`.claude-plugin/plugin.json`,
+     `.claude-plugin/marketplace.json`) -- each carries its own `"version"`.
+   - manifests, install instructions, constants files, docker tags, CI configs,
+     documentation site configs, compatibility tables.
+
+   cc-rpi is docs/generic with NO manifest: git tag + CHANGELOG are the source of
+   truth and every other version string is hand-maintained -- the grep is
+   mandatory. This repo has repeatedly shipped with the README badge and
+   `.claude-plugin/*.json` left 1-2 releases stale; do not let that recur.
 
 5. **Detect branching strategy:**
    - Check if current branch is main/master
@@ -82,7 +101,11 @@ After the user provides a version number, prepare all files for release. Do not 
    Present the draft entry to the user for review. Apply their edits before writing.
 
 3. **Update version references** in all files identified in Step 1:
-   README badges, install instructions, constants, docker tags, etc.
+   README badges (all occurrences on the line), plugin/marketplace manifests,
+   install instructions, constants, docker tags, etc. Then re-run the grep from
+   Step 1 for the OLD version and confirm nothing remains outside CHANGELOG
+   history -- a non-empty result (other than dated CHANGELOG entries) means a
+   file was missed.
 
 4. **Run verification commands** sequentially (chain with `&&` or `;`, never parallel Bash calls):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+
+- **Hardened `/release`'s version scan** (`templates/commands/release.md` +
+  active `.claude/commands/release.md`): Step 1 now mandates a `git grep` of the
+  current version string instead of relying on memory, and explicitly names the
+  commonly-missed locations (shield.io badges where the version repeats 3x on one
+  line, and `.claude-plugin/*.json` manifests). Step 2 adds a post-bump re-grep
+  of the OLD version to confirm nothing was missed. Motivated by the README badge
+  and plugin manifests repeatedly shipping 1-2 releases stale.
+
 ## [1.26.0] - 2026-07-24
 
 ### Added

--- a/templates/commands/release.md
+++ b/templates/commands/release.md
@@ -26,9 +26,27 @@ Gather release context before making any changes.
    git log <last-tag>..HEAD --oneline
    ```
 
-4. **Identify all version-bearing files** -- scan for the current version string across the project:
-   manifests, README badges, install instructions, constants files, docker tags,
-   CI configs, documentation site configs.
+4. **Identify all version-bearing files** -- do NOT rely on memory or a static
+   list. Grep the CURRENT version string across the whole repo so nothing is
+   missed:
+
+   ```bash
+   git grep -n -F "1.2.3"; git grep -n -F "v1.2.3"   # both bare and v-prefixed
+   ```
+
+   Hand-maintained version strings drift silently when there is no canonical
+   manifest. Explicitly confirm these commonly-missed locations, even if a scoped
+   scan would skip them:
+   - **README/docs shield.io badges** -- the version can appear 3x on ONE line
+     (badge label text, the `img.shields.io` URL, and the `releases/tag/` link href).
+   - **Plugin/marketplace manifests** (e.g. `.claude-plugin/plugin.json`,
+     `.claude-plugin/marketplace.json`) -- each carries its own `"version"`.
+   - manifests, install instructions, constants files, docker tags, CI configs,
+     documentation site configs, compatibility tables.
+
+   For docs/generic repos with no manifest, git tag + CHANGELOG are the source of
+   truth and every other version string is hand-maintained -- the grep is
+   mandatory, not optional.
 
 5. **Detect branching strategy:**
    - Check if current branch is main/master
@@ -82,7 +100,11 @@ After the user provides a version number, prepare all files for release. Do not 
    Present the draft entry to the user for review. Apply their edits before writing.
 
 3. **Update version references** in all files identified in Step 1:
-   README badges, install instructions, constants, docker tags, etc.
+   README badges (all occurrences on the line), plugin/marketplace manifests,
+   install instructions, constants, docker tags, etc. Then re-run the grep from
+   Step 1 for the OLD version and confirm nothing remains outside CHANGELOG
+   history -- a non-empty result (other than dated CHANGELOG entries) means a
+   file was missed.
 
 4. **Run verification commands** sequentially (chain with `&&` or `;`, never parallel Bash calls):
 


### PR DESCRIPTION
## Summary

`/release`'s version-bump step has repeatedly shipped with stale version strings — the README badge sat at v1.24.0 through the v1.25.0 release, and both `.claude-plugin/*.json` manifests were two releases behind at v1.26.0 time. Root cause: Step 1's "identify version-bearing files" relied on a static prose list and didn't name these locations.

## Changes

- **Step 1** now mandates a `git grep` of the current version (bare + `v`-prefixed) instead of relying on memory, and explicitly calls out the recurring blind spots: shield.io badges (version repeats 3× on one line) and `.claude-plugin/*.json` manifests.
- **Step 2** adds a post-bump re-grep of the OLD version to confirm nothing outside CHANGELOG history remains.
- Applied to both `templates/commands/release.md` (generic) and the active `.claude/commands/release.md` (with the cc-rpi-specific callout), per the consistency-sweep rule.

No behavior change to any shipped code — documentation/process hardening only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ET5W9ThgwtCt28wGf2Jw3V